### PR TITLE
v0.5.2: Strict validation, batch validation, onlyMetadata export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ coverage/
 plans/
 
 # Invoices
-invoices/
+/invoices/
 
 # OpenSpec archive
 openspec/changes/archive/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [0.5.2] - Unreleased
 
+### Added
+- **Batch invoice validation** — `--validate` flag now works for directory batch sends in CLI and `validate` option in programmatic `uploadBatch()`. Invalid invoices are caught before upload with per-file error reporting.
+
 ### Fixed
 - **Strict Invoice validation** — unknown XML elements not defined in KSeF schemas now rejected client-side instead of silently passing through to KSeF (error 450).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2] - Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
 ## [0.5.1] - 2026-03-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - **Batch invoice validation** — `--validate` flag now works for directory batch sends in CLI and `validate` option in programmatic `uploadBatch()`. Invalid invoices are caught before upload with per-file error reporting.
+- **OnlyMetadata export** — `--onlyMetadata` flag for `invoice export` and `invoice export-incremental` CLI commands to download metadata without invoice XML files.
+- **`SCHEMA_TYPES` runtime array** — exported list of all valid schema type identifiers for runtime use.
 
 ### Fixed
 - **Strict Invoice validation** — unknown XML elements not defined in KSeF schemas now rejected client-side instead of silently passing through to KSeF (error 450).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [0.5.2] - Unreleased
 
-### Added
-
-### Changed
-
 ### Fixed
+- **Strict Invoice validation** — unknown XML elements not defined in KSeF schemas now rejected client-side instead of silently passing through to KSeF (error 450).
 
 ## [0.5.1] - 2026-03-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,19 @@ The web portal is used for token generation, permission management, and invoice 
 
 `KSEF_TOKEN` and `KSEF_NIP` are set in the current shell environment. Use them for CLI login: `ksef auth login --token "$KSEF_TOKEN" --nip "$KSEF_NIP" --env prod`.
 
+### Invoice upload flow (CLI)
+
+```bash
+ksef auth login --token "$KSEF_TOKEN" --nip "$KSEF_NIP"
+ksef session open              # 1. Open online session (required before sending)
+ksef invoice send file.xml     # 2. Send invoice
+ksef session invoices          # 3. Verify invoice status (check for errors/duplicates)
+ksef invoice query --from 2026-01-01  # Query invoices by date range
+ksef session close             # 4. Close session (optional)
+```
+
+Invoice number (`P_2` in XML) must be unique — resubmitting gives error 440 (Duplikat faktury).
+
 ### OpenAPI spec
 
 `docs/open-api.json` is the KSeF API OpenAPI specification (source of truth, v2.3.0-te). Per-domain chunks in `docs/openapi-chunks/` (16 files). Regenerate with `yarn split-openapi`. Validate coverage with `yarn check-api`.

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ const challenge = await client.auth.getChallenge();
 
 ```bash
 ksef auth login --token "$KSEF_TOKEN" --nip "$KSEF_NIP"
-ksef session open
-ksef invoice send invoice.xml
-ksef session close
+ksef session open              # 1. Open online session (required)
+ksef invoice send invoice.xml  # 2. Send invoice
+ksef session invoices          # 3. Verify invoice status
+ksef session close             # 4. Close session (optional)
 ```
 
 See the [documentation](https://flopsstuff.github.io/ksef-client-ts) for full usage, [API reference](https://flopsstuff.github.io/ksef-client-ts/api-reference), and [CLI reference](https://flopsstuff.github.io/ksef-client-ts/cli).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ksef-client-ts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "TypeScript client for the Polish National e-Invoice System (KSeF) API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/scripts/generate-invoice-schemas.mjs
+++ b/scripts/generate-invoice-schemas.mjs
@@ -775,7 +775,7 @@ class ZodEmitter {
         for (const attr of typeDef.attributes) {
           props.push(this.generateAttributeProp(attr));
         }
-        return `z.object({ ${props.join(', ')} })`;
+        return `z.object({ ${props.join(', ')} }).strict()`;
       }
       return baseSchema;
     }
@@ -813,10 +813,10 @@ class ZodEmitter {
 
     const allProps = [...baseProps, ...ownProps];
     if (allProps.length === 0) {
-      return 'z.object({})';
+      return 'z.object({}).strict()';
     }
 
-    return `z.object({\n${allProps.map(p => '  ' + p).join(',\n')}\n})`;
+    return `z.object({\n${allProps.map(p => '  ' + p).join(',\n')}\n}).strict()`;
   }
 
   generateContentElements(content) {
@@ -855,15 +855,15 @@ class ZodEmitter {
         // Nested sequence within choice
         if (elem.inlineType && elem.inlineType.content) {
           const seqProps = this.generateContentElements(elem.inlineType.content);
-          branches.push(`z.object({ ${[...baseProps, ...attrProps, ...seqProps].join(', ')} })`);
+          branches.push(`z.object({ ${[...baseProps, ...attrProps, ...seqProps].join(', ')} }).strict()`);
         }
       } else {
         const prop = this.generateElementProp(elem, false);
-        branches.push(`z.object({ ${[...baseProps, ...attrProps, prop].join(', ')} })`);
+        branches.push(`z.object({ ${[...baseProps, ...attrProps, prop].join(', ')} }).strict()`);
       }
     }
 
-    if (branches.length === 0) return 'z.object({})';
+    if (branches.length === 0) return 'z.object({}).strict()';
     if (branches.length === 1) return branches[0];
 
     const isOptional = content.minOccurs === '0';
@@ -1129,6 +1129,9 @@ function generateIndex(namespaces) {
   lines.push('');
   lines.push('/** Schema type identifiers */');
   lines.push(`export type SchemaType = ${SCHEMA_DEFS.map(d => `'${d.id}'`).join(' | ')};`);
+  lines.push('');
+  lines.push('/** All valid schema type values as a runtime array. */');
+  lines.push(`export const SCHEMA_TYPES: readonly SchemaType[] = [${SCHEMA_DEFS.map(d => `'${d.id}'`).join(', ')}] as const;`);
   lines.push('');
 
   // Namespace map for auto-detection — only include unique namespaces

--- a/src/cli/commands/export-incremental.ts
+++ b/src/cli/commands/export-incremental.ts
@@ -31,6 +31,7 @@ export const exportIncremental = defineCommand({
     stateFile: { type: 'string', description: 'HWM state file path (default: ./ksef-hwm-state.json)' },
     outputDir: { type: 'string', description: 'Output directory for exported parts (default: ./ksef-exports/)' },
     maxIterations: { type: 'string', description: 'Max export iterations (default: 20)' },
+    onlyMetadata: { type: 'boolean', description: 'Export metadata only (no invoice XML)' },
     env: { type: 'string', description: 'Environment (test/demo/prod)' },
     json: { type: 'boolean', description: 'Output as JSON' },
     verbose: { type: 'boolean', description: 'Show HTTP request/response details' },
@@ -72,6 +73,7 @@ export const exportIncremental = defineCommand({
         windowTo: to,
         continuationPoints,
         maxIterations,
+        onlyMetadata: args.onlyMetadata as boolean | undefined,
         store,
         pollOptions: { intervalMs: 2000 },
         onIterationComplete: (iteration, iterResult) => {

--- a/src/cli/commands/export-incremental.ts
+++ b/src/cli/commands/export-incremental.ts
@@ -73,7 +73,7 @@ export const exportIncremental = defineCommand({
         windowTo: to,
         continuationPoints,
         maxIterations,
-        onlyMetadata: args.onlyMetadata as boolean | undefined,
+        onlyMetadata: args.onlyMetadata,
         store,
         pollOptions: { intervalMs: 2000 },
         onIterationComplete: (iteration, iterResult) => {

--- a/src/cli/commands/invoice.ts
+++ b/src/cli/commands/invoice.ts
@@ -171,11 +171,14 @@ const send = defineCommand({
           throw new Error(`Document type "${formCode.systemCode}" is not supported in batch sessions. PEF/PEF_KOR require online sessions.`);
         }
 
+        // Read all files once — reused for validation, metadata, and batch hash
+        const fileBuffers = xmlFiles.map(file => ({ file, content: fs.readFileSync(file) }));
+
         if (args.validate) {
-          const { validateBatch } = await import('../../validation/invoice-validator.js');
-          const invoicesToValidate = xmlFiles.map(file => ({
+          const { validateBatch, batchValidationDetails } = await import('../../validation/invoice-validator.js');
+          const invoicesToValidate = fileBuffers.map(({ file, content }) => ({
             fileName: path.basename(file),
-            xml: fs.readFileSync(file, 'utf-8'),
+            xml: content.toString('utf-8'),
           }));
           if (!args.json) consola.start(`Validating ${invoicesToValidate.length} invoices...`);
           const batchResult = await validateBatch(invoicesToValidate);
@@ -183,12 +186,7 @@ const send = defineCommand({
             const invalidCount = batchResult.results.filter(r => !r.result.valid).length;
             throw new KSeFValidationError(
               `Validation failed: ${invalidCount} of ${xmlFiles.length} invoices invalid`,
-              batchResult.results
-                .filter(r => !r.result.valid)
-                .flatMap(r => r.result.errors.map(e => ({
-                  field: `${r.fileName}:${e.path ?? ''}`,
-                  message: e.message,
-                }))),
+              batchValidationDetails(batchResult),
             );
           }
           if (!args.json) consola.success(`All ${xmlFiles.length} invoices valid.`);
@@ -198,9 +196,7 @@ const send = defineCommand({
         await client.crypto.init();
         const encryptionData = client.crypto.getEncryptionData();
 
-        // Read all files and compute metadata
-        const parts = xmlFiles.map((file, i) => {
-          const content = fs.readFileSync(file);
+        const parts = fileBuffers.map(({ content }, i) => {
           const metadata = client.crypto.getFileMetadata(new Uint8Array(content));
           return {
             data: content.buffer as ArrayBuffer,
@@ -209,8 +205,7 @@ const send = defineCommand({
           };
         });
 
-        // Compute overall batch file info
-        const totalContent = Buffer.concat(xmlFiles.map((f) => fs.readFileSync(f)));
+        const totalContent = Buffer.concat(fileBuffers.map(({ content }) => content));
         const totalMetadata = client.crypto.getFileMetadata(new Uint8Array(totalContent));
         const batchFileInfo = {
           fileSize: totalMetadata.fileSize,

--- a/src/cli/commands/invoice.ts
+++ b/src/cli/commands/invoice.ts
@@ -118,7 +118,7 @@ const send = defineCommand({
       if (args.stream) {
         // Stream-based batch upload from a ZIP file
         if (args.validate) {
-          consola.warn('--validate is only supported for single-file sends, skipping validation.');
+          consola.warn('--validate is not supported in stream mode. Run `ksef invoice validate <path>` before sending, or remove --stream.');
         }
 
         if (!filePath.endsWith('.zip') || stat.isDirectory()) {
@@ -155,10 +155,6 @@ const send = defineCommand({
 
       if (stat.isDirectory()) {
         // Batch mode: send all XMLs in directory
-        if (args.validate) {
-          consola.warn('--validate is only supported for single-file sends, skipping validation.');
-        }
-
         const xmlFiles = fs.readdirSync(filePath)
           .filter((f) => f.endsWith('.xml'))
           .map((f) => path.join(filePath, f));
@@ -173,6 +169,29 @@ const send = defineCommand({
 
         if (!validateFormCodeForSession(formCode, 'batch')) {
           throw new Error(`Document type "${formCode.systemCode}" is not supported in batch sessions. PEF/PEF_KOR require online sessions.`);
+        }
+
+        if (args.validate) {
+          const { validateBatch } = await import('../../validation/invoice-validator.js');
+          const invoicesToValidate = xmlFiles.map(file => ({
+            fileName: path.basename(file),
+            xml: fs.readFileSync(file, 'utf-8'),
+          }));
+          if (!args.json) consola.start(`Validating ${invoicesToValidate.length} invoices...`);
+          const batchResult = await validateBatch(invoicesToValidate);
+          if (!batchResult.valid) {
+            const invalidCount = batchResult.results.filter(r => !r.result.valid).length;
+            throw new KSeFValidationError(
+              `Validation failed: ${invalidCount} of ${xmlFiles.length} invoices invalid`,
+              batchResult.results
+                .filter(r => !r.result.valid)
+                .flatMap(r => r.result.errors.map(e => ({
+                  field: `${r.fileName}:${e.path ?? ''}`,
+                  message: e.message,
+                }))),
+            );
+          }
+          if (!args.json) consola.success(`All ${xmlFiles.length} invoices valid.`);
         }
 
         if (!args.json) consola.start(`Sending ${xmlFiles.length} invoices via batch session...`);

--- a/src/cli/commands/invoice.ts
+++ b/src/cli/commands/invoice.ts
@@ -370,6 +370,7 @@ const exportCmd = defineCommand({
   meta: { name: 'export', description: 'Start invoice export' },
   args: {
     ...QUERY_FILTER_ARGS,
+    onlyMetadata: { type: 'boolean', description: 'Export metadata only (no invoice XML)' },
     env: { type: 'string', description: 'Environment (test/demo/prod)' },
     json: { type: 'boolean', description: 'Output as JSON' },
     verbose: { type: 'boolean', description: 'Show HTTP request/response details' },
@@ -387,7 +388,7 @@ const exportCmd = defineCommand({
       const filters = buildQueryFilters(args);
 
       const result = await client.invoices.exportInvoices(
-        { encryption: encryptionData.encryptionInfo, filters },
+        { encryption: encryptionData.encryptionInfo, filters, onlyMetadata: args.onlyMetadata },
       );
 
       if (args.json) {

--- a/src/cli/error-handler.ts
+++ b/src/cli/error-handler.ts
@@ -3,6 +3,7 @@ import { KSeFRateLimitError } from '../errors/ksef-rate-limit-error.js';
 import { KSeFUnauthorizedError } from '../errors/ksef-unauthorized-error.js';
 import { KSeFForbiddenError } from '../errors/ksef-forbidden-error.js';
 import { KSeFApiError } from '../errors/ksef-api-error.js';
+import { KSeFValidationError } from '../errors/ksef-validation-error.js';
 
 export async function withErrorHandler(fn: () => Promise<void>): Promise<void> {
   try {
@@ -40,6 +41,14 @@ export async function withErrorHandler(fn: () => Promise<void>): Promise<void> {
         consola.info('Hint: Run `ksef auth login` to authenticate.');
       } else if (error.statusCode === 404) {
         consola.info('Hint: Check if the resource reference is correct.');
+      }
+      process.exit(1);
+    }
+
+    if (error instanceof KSeFValidationError) {
+      consola.error(error.message);
+      for (const detail of error.details) {
+        consola.error(`  ${detail.field ? `[${detail.field}] ` : ''}${detail.message}`);
       }
       process.exit(1);
     }

--- a/src/cli/error-handler.ts
+++ b/src/cli/error-handler.ts
@@ -30,6 +30,14 @@ export async function withErrorHandler(fn: () => Promise<void>): Promise<void> {
       process.exit(1);
     }
 
+    if (error instanceof KSeFValidationError) {
+      consola.error(error.message);
+      for (const detail of error.details) {
+        consola.error(`  ${detail.field ? `[${detail.field}] ` : ''}${detail.message}`);
+      }
+      process.exit(1);
+    }
+
     if (error instanceof KSeFApiError) {
       consola.error(`KSeF API error (HTTP ${error.statusCode}): ${error.message}`);
       if (error.errorResponse?.exception?.exceptionDetailList) {
@@ -41,14 +49,6 @@ export async function withErrorHandler(fn: () => Promise<void>): Promise<void> {
         consola.info('Hint: Run `ksef auth login` to authenticate.');
       } else if (error.statusCode === 404) {
         consola.info('Hint: Check if the resource reference is correct.');
-      }
-      process.exit(1);
-    }
-
-    if (error instanceof KSeFValidationError) {
-      consola.error(error.message);
-      for (const detail of error.details) {
-        consola.error(`  ${detail.field ? `[${detail.field}] ` : ''}${detail.message}`);
       }
       process.exit(1);
     }

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -16,7 +16,7 @@ export {
 export { xmlToObject, type XmlConversionResult } from './xml-to-object.js';
 export { SchemaRegistry } from './schema-registry.js';
 export {
-  validate, validateBatch, validateWellFormedness, validateSchema, validateBusinessRules,
+  validate, validateBatch, batchValidationDetails, validateWellFormedness, validateSchema, validateBusinessRules,
   type InvoiceValidationResult, type InvoiceValidationError,
   type InvoiceValidationErrorCode, type ValidateOptions, type BatchValidationResult,
 } from './invoice-validator.js';

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -16,7 +16,7 @@ export {
 export { xmlToObject, type XmlConversionResult } from './xml-to-object.js';
 export { SchemaRegistry } from './schema-registry.js';
 export {
-  validate, validateWellFormedness, validateSchema, validateBusinessRules,
+  validate, validateBatch, validateWellFormedness, validateSchema, validateBusinessRules,
   type InvoiceValidationResult, type InvoiceValidationError,
-  type InvoiceValidationErrorCode, type ValidateOptions,
+  type InvoiceValidationErrorCode, type ValidateOptions, type BatchValidationResult,
 } from './invoice-validator.js';

--- a/src/validation/invoice-validator.ts
+++ b/src/validation/invoice-validator.ts
@@ -322,3 +322,18 @@ export async function validateBatch(
   }
   return { valid: results.every(r => r.result.valid), results };
 }
+
+/**
+ * Build a flat array of `ValidationDetail` from batch results, for use with `KSeFValidationError`.
+ * Prefixes each error's field with the file name for traceability.
+ */
+export function batchValidationDetails(
+  batch: BatchValidationResult,
+): Array<{ field?: string; message: string }> {
+  return batch.results
+    .filter(r => !r.result.valid)
+    .flatMap(r => r.result.errors.map(e => ({
+      field: e.path ? `${r.fileName}:${e.path}` : r.fileName,
+      message: e.message,
+    })));
+}

--- a/src/validation/invoice-validator.ts
+++ b/src/validation/invoice-validator.ts
@@ -23,6 +23,7 @@ export type InvoiceValidationErrorCode =
   | 'MAX_OCCURS_EXCEEDED'
   | 'UNKNOWN_SCHEMA'
   | 'SCHEMA_VALIDATION_ERROR'
+  | 'UNRECOGNIZED_KEY'
   | 'INVALID_NIP_CHECKSUM'
   | 'INVALID_PESEL_CHECKSUM'
   | 'FUTURE_INVOICE_DATE';
@@ -160,6 +161,8 @@ function mapZodErrorCode(issue: { code?: string; input?: unknown }): InvoiceVali
       return 'PATTERN_MISMATCH';
     case 'too_big':
       return 'MAX_OCCURS_EXCEEDED';
+    case 'unrecognized_keys':
+      return 'UNRECOGNIZED_KEY';
     default:
       return 'SCHEMA_VALIDATION_ERROR';
   }

--- a/src/validation/invoice-validator.ts
+++ b/src/validation/invoice-validator.ts
@@ -300,3 +300,25 @@ export async function validate(
   // Carry forward schema type from L2 (immutable — don't mutate l3)
   return { ...l3, schemaType: l2.schemaType };
 }
+
+// ─── Batch validation ──────────────────────────────────────────────────────
+
+export interface BatchValidationResult {
+  valid: boolean;
+  results: Array<{ fileName: string; result: InvoiceValidationResult }>;
+}
+
+/**
+ * Validate multiple invoices, collecting results for each file.
+ * Sequential execution — first call lazy-loads the Zod schema, subsequent calls use cache.
+ */
+export async function validateBatch(
+  invoices: Array<{ fileName: string; xml: string }>,
+  options?: ValidateOptions,
+): Promise<BatchValidationResult> {
+  const results = [];
+  for (const { fileName, xml } of invoices) {
+    results.push({ fileName, result: await validate(xml, options) });
+  }
+  return { valid: results.every(r => r.result.valid), results };
+}

--- a/src/validation/schemas/fa2.ts
+++ b/src/validation/schemas/fa2.ts
@@ -10,11 +10,11 @@ const TDataCzas = z.string();
 const TZnakowy = z.string().min(1).max(256);
 
 const TNaglowek = z.object({
-  "KodFormularza": z.object({ '#text': TKodFormularza, "@kodSystemowy": z.literal("FA (2)"), "@wersjaSchemy": z.literal("1-0E") }),
+  "KodFormularza": z.object({ '#text': TKodFormularza, "@kodSystemowy": z.literal("FA (2)"), "@wersjaSchemy": z.literal("1-0E") }).strict(),
   "WariantFormularza": z.literal("2"),
   "DataWytworzeniaFa": z.string(),
   "SystemInfo": TZnakowy.optional()
-});
+}).strict();
 
 const TKodyKrajowUE = z.enum(["AT", "BE", "BG", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "EL", "HR", "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE", "XI"]);
 
@@ -25,7 +25,7 @@ const TZnakowy512 = z.string().min(1).max(512);
 const TPodmiot1 = z.object({
   "NIP": TNrNIP,
   "Nazwa": TZnakowy512
-});
+}).strict();
 
 const TKodKraju = z.enum(["AF", "AX", "AL", "DZ", "AD", "AO", "AI", "AQ", "AG", "AN", "SA", "AR", "AM", "AW", "AU", "AT", "AZ", "BS", "BH", "BD", "BB", "BE", "BZ", "BJ", "BM", "BT", "BY", "BO", "BQ", "BA", "BW", "BR", "BN", "IO", "BG", "BF", "BI", "XC", "CL", "CN", "HR", "CW", "CY", "TD", "ME", "DK", "DM", "DO", "DJ", "EG", "EC", "ER", "EE", "ET", "FK", "FJ", "PH", "FI", "FR", "TF", "GA", "GM", "GH", "GI", "GR", "GD", "GL", "GE", "GU", "GG", "GY", "GF", "GP", "GT", "GN", "GQ", "GW", "HT", "ES", "HN", "HK", "IN", "ID", "IQ", "IR", "IE", "IS", "IL", "JM", "JP", "YE", "JE", "JO", "KY", "KH", "CM", "CA", "QA", "KZ", "KE", "KG", "KI", "CO", "KM", "CG", "CD", "KP", "XK", "CR", "CU", "KW", "LA", "LS", "LB", "LR", "LY", "LI", "LT", "LV", "LU", "MK", "MG", "YT", "MO", "MW", "MV", "MY", "ML", "MT", "MP", "MA", "MQ", "MR", "MU", "MX", "XL", "FM", "UM", "MD", "MC", "MN", "MS", "MZ", "MM", "NA", "NR", "NP", "NL", "DE", "NE", "NG", "NI", "NU", "NF", "NO", "NC", "NZ", "PS", "OM", "PK", "PW", "PA", "PG", "PY", "PE", "PN", "PF", "PL", "GS", "PT", "PR", "CF", "CZ", "KR", "ZA", "RE", "RU", "RO", "RW", "EH", "BL", "KN", "LC", "MF", "VC", "SV", "WS", "AS", "SM", "SN", "RS", "SC", "SL", "SG", "SK", "SI", "SO", "LK", "PM", "US", "SZ", "SD", "SS", "SR", "SJ", "SH", "SY", "CH", "SE", "TJ", "TH", "TW", "TZ", "TG", "TK", "TO", "TT", "TN", "TR", "TM", "TV", "UG", "UA", "UY", "UZ", "VU", "WF", "VA", "HU", "VE", "GB", "VN", "IT", "TL", "CI", "BV", "CX", "IM", "SX", "CK", "VI", "VG", "HM", "CC", "MH", "FO", "SB", "ST", "TC", "ZM", "CV", "ZW", "AE", "XI"]);
 
@@ -36,7 +36,7 @@ const TAdres = z.object({
   "AdresL1": TZnakowy512,
   "AdresL2": TZnakowy512.optional(),
   "GLN": TGLN.optional()
-});
+}).strict();
 
 const TAdresEmail = z.string().min(3).max(255).regex(/^(.)+@(.)+$/);
 
@@ -58,7 +58,7 @@ const TPodmiot2 = z.object({
   "NrID": z.string().min(1).max(50).regex(/^[a-zA-Z0-9]{1,50}$/).optional(),
   "BrakID": TWybor1.optional(),
   "Nazwa": TZnakowy512.optional()
-});
+}).strict();
 
 const TZnakowy50 = z.string().min(1).max(50);
 
@@ -75,7 +75,7 @@ const TPodmiot3 = z.object({
   "NrID": z.string().min(1).max(50).regex(/^[a-zA-Z0-9]{1,50}$/).optional(),
   "BrakID": TWybor1.optional(),
   "Nazwa": TZnakowy512.optional()
-});
+}).strict();
 
 const TRolaPodmiotu3 = z.enum(["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]);
 
@@ -107,7 +107,7 @@ const TKluczWartosc = z.object({
   "NrWiersza": TNaturalny.optional(),
   "Klucz": TZnakowy,
   "Wartosc": TZnakowy
-});
+}).strict();
 
 const TKwotowy2 = z.string().regex(/^-?([1-9]\d{0,13}|0)(\.\d{1,8})?$/);
 
@@ -131,7 +131,7 @@ const TRachunekBankowy = z.object({
   "RachunekWlasnyBanku": TRachunekWlasnyBanku.optional(),
   "NazwaBanku": TZnakowy.optional(),
   "OpisRachunku": TZnakowy.optional()
-});
+}).strict();
 
 const TRodzajTransportu = z.enum(["1", "2", "3", "4", "5", "7", "8"]);
 
@@ -158,13 +158,13 @@ export const FA2Schema = z.object({
   "AdresL1": TZnakowy512,
   "AdresL2": TZnakowy512.optional(),
   "GLN": TGLN.optional()
-}).optional(),
+}).strict().optional(),
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Email": TAdresEmail.optional(),
   "Telefon": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "StatusInfoPodatnika": TStatusInfoPodatnika.optional()
-}),
+}).strict(),
   "Podmiot2": z.object({
   "NrEORI": TZnakowy.optional(),
   "DaneIdentyfikacyjne": TPodmiot2,
@@ -173,10 +173,10 @@ export const FA2Schema = z.object({
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Email": TAdresEmail.optional(),
   "Telefon": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "NrKlienta": TZnakowy.optional(),
   "IDNabywcy": z.string().min(1).max(32).optional()
-}),
+}).strict(),
   "Podmiot3": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "IDNabywcy": z.string().min(1).max(32).optional(),
   "NrEORI": TZnakowy.optional(),
@@ -186,13 +186,13 @@ export const FA2Schema = z.object({
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Email": TAdresEmail.optional(),
   "Telefon": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "Rola": TRolaPodmiotu3.optional(),
   "RolaInna": TWybor1.optional(),
   "OpisRoli": TZnakowy.optional(),
   "Udzial": TProcentowy.optional(),
   "NrKlienta": TZnakowy.optional()
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "PodmiotUpowazniony": z.object({
   "NrEORI": TZnakowy.optional(),
   "DaneIdentyfikacyjne": TPodmiot1,
@@ -201,9 +201,9 @@ export const FA2Schema = z.object({
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "EmailPU": TAdresEmail.optional(),
   "TelefonPU": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "RolaPU": TRolaPodmiotuUpowaznionego
-}).optional(),
+}).strict().optional(),
   "Fa": z.object({
   "KodWaluty": TKodWaluty,
   "P_1": TDataT,
@@ -214,7 +214,7 @@ export const FA2Schema = z.object({
   "OkresFa": z.object({
   "P_6_Od": TDataT,
   "P_6_Do": TDataT
-}).optional(),
+}).strict().optional(),
   "P_13_1": TKwotowy.optional(),
   "P_14_1": TKwotowy.optional(),
   "P_14_1W": TKwotowy.optional(),
@@ -244,7 +244,7 @@ export const FA2Schema = z.object({
   "P_17": TWybor1_2,
   "P_18": TWybor1_2,
   "P_18A": TWybor1_2,
-  "Zwolnienie": z.union([z.object({ "P_19": TWybor1, "P_19A": TZnakowy.optional(), "P_19B": TZnakowy.optional(), "P_19C": TZnakowy.optional() }), z.object({ "P_19N": TWybor1 })]),
+  "Zwolnienie": z.union([z.object({ "P_19": TWybor1, "P_19A": TZnakowy.optional(), "P_19B": TZnakowy.optional(), "P_19C": TZnakowy.optional() }).strict(), z.object({ "P_19N": TWybor1 }).strict()]),
   "NoweSrodkiTransportu": z.union([z.object({ "P_22": TWybor1, "P_42_5": TWybor1_2, "NowySrodekTransportu": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "P_22A": TDataT,
   "P_NrWierszaNST": TNaturalny,
@@ -263,10 +263,10 @@ export const FA2Schema = z.object({
   "P_22C1": TZnakowy.optional(),
   "P_22D": TZnakowy.optional(),
   "P_22D1": TZnakowy.optional()
-})).min(1).max(10000)) }), z.object({ "P_22N": TWybor1 })]),
+}).strict()).min(1).max(10000)) }).strict(), z.object({ "P_22N": TWybor1 }).strict()]),
   "P_23": TWybor1_2,
-  "PMarzy": z.union([z.object({ "P_PMarzy": TWybor1, "P_PMarzy_2": TWybor1.optional(), "P_PMarzy_3_1": TWybor1.optional(), "P_PMarzy_3_2": TWybor1.optional(), "P_PMarzy_3_3": TWybor1.optional() }), z.object({ "P_PMarzyN": TWybor1 })])
-}),
+  "PMarzy": z.union([z.object({ "P_PMarzy": TWybor1, "P_PMarzy_2": TWybor1.optional(), "P_PMarzy_3_1": TWybor1.optional(), "P_PMarzy_3_2": TWybor1.optional(), "P_PMarzy_3_3": TWybor1.optional() }).strict(), z.object({ "P_PMarzyN": TWybor1 }).strict()])
+}).strict(),
   "RodzajFaktury": TRodzajFaktury,
   "PrzyczynaKorekty": TZnakowy.optional(),
   "TypKorekty": TTypKorekty.optional(),
@@ -276,30 +276,30 @@ export const FA2Schema = z.object({
   "NrKSeF": TWybor1.optional(),
   "NrKSeFFaKorygowanej": TNumerKSeF.optional(),
   "NrKSeFN": TWybor1.optional()
-})).min(1)).optional(),
+}).strict()).min(1)).optional(),
   "OkresFaKorygowanej": TZnakowy.optional(),
   "NrFaKorygowany": TZnakowy.optional(),
   "Podmiot1K": z.object({
   "PrefiksPodatnika": TKodyKrajowUE.optional(),
   "DaneIdentyfikacyjne": TPodmiot1,
   "Adres": TAdres
-}).optional(),
+}).strict().optional(),
   "Podmiot2K": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "DaneIdentyfikacyjne": TPodmiot2,
   "Adres": TAdres.optional(),
   "IDNabywcy": z.string().min(1).max(32).optional()
-})).min(0).max(101)).optional(),
+}).strict()).min(0).max(101)).optional(),
   "P_15ZK": TKwotowy.optional(),
   "KursWalutyZK": TIlosci.optional(),
   "ZaliczkaCzesciowa": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "P_6Z": TDataT,
   "P_15Z": TKwotowy,
   "KursWalutyZW": TIlosci.optional()
-})).min(0).max(31)).optional(),
+}).strict()).min(0).max(31)).optional(),
   "FP": TWybor1.optional(),
   "TP": TWybor1.optional(),
   "DodatkowyOpis": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(TKluczWartosc).min(0).max(10000)).optional(),
-  "FakturaZaliczkowa": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.union([z.object({ "NrKSeFZN": TWybor1, "NrFaZaliczkowej": TZnakowy }), z.object({ "NrKSeFFaZaliczkowej": TNumerKSeF })])).min(0).max(100)).optional(),
+  "FakturaZaliczkowa": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.union([z.object({ "NrKSeFZN": TWybor1, "NrFaZaliczkowej": TZnakowy }).strict(), z.object({ "NrKSeFFaZaliczkowej": TNumerKSeF }).strict()])).min(0).max(100)).optional(),
   "ZwrotAkcyzy": TWybor1.optional(),
   "FaWiersz": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "NrWierszaFa": TNaturalny,
@@ -327,21 +327,21 @@ export const FA2Schema = z.object({
   "Procedura": TOznaczenieProcedury.optional(),
   "KursWaluty": TIlosci.optional(),
   "StanPrzed": TWybor1.optional()
-})).min(0).max(10000)).optional(),
+}).strict()).min(0).max(10000)).optional(),
   "Rozliczenie": z.object({
   "Obciazenia": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Kwota": TKwotowy,
   "Powod": TZnakowy
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "SumaObciazen": TKwotowy.optional(),
   "Odliczenia": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Kwota": TKwotowy,
   "Powod": TZnakowy
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "SumaOdliczen": TKwotowy.optional(),
   "DoZaplaty": TKwotowy.optional(),
   "DoRozliczenia": TKwotowy.optional()
-}).optional(),
+}).strict().optional(),
   "Platnosc": z.object({
   "Zaplacono": TWybor1.optional(),
   "DataZaplaty": TData.optional(),
@@ -349,11 +349,11 @@ export const FA2Schema = z.object({
   "ZaplataCzesciowa": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "KwotaZaplatyCzesciowej": TKwotowy,
   "DataZaplatyCzesciowej": TData
-})).min(1).max(100)).optional(),
+}).strict()).min(1).max(100)).optional(),
   "TerminPlatnosci": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Termin": TData,
   "TerminOpis": TZnakowy.optional()
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "FormaPlatnosci": TFormaPlatnosci.optional(),
   "PlatnoscInna": TWybor1.optional(),
   "OpisPlatnosci": TZnakowy.optional(),
@@ -362,17 +362,17 @@ export const FA2Schema = z.object({
   "Skonto": z.object({
   "WarunkiSkonta": TZnakowy,
   "WysokoscSkonta": TZnakowy
-}).optional()
-}).optional(),
+}).strict().optional()
+}).strict().optional(),
   "WarunkiTransakcji": z.object({
   "Umowy": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "DataUmowy": TData.optional(),
   "NrUmowy": TZnakowy.optional()
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "Zamowienia": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "DataZamowienia": TData.optional(),
   "NrZamowienia": TZnakowy.optional()
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "NrPartiiTowaru": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(TZnakowy).min(0).max(1000)).optional(),
   "WarunkiDostawy": TZnakowy.optional(),
   "KursUmowny": TIlosci.optional(),
@@ -384,7 +384,7 @@ export const FA2Schema = z.object({
   "Przewoznik": z.object({
   "DaneIdentyfikacyjne": TPodmiot2,
   "AdresPrzewoznika": TAdres
-}).optional(),
+}).strict().optional(),
   "NrZleceniaTransportu": TZnakowy.optional(),
   "OpisLadunku": TLadunek.optional(),
   "LadunekInny": TWybor1.optional(),
@@ -395,9 +395,9 @@ export const FA2Schema = z.object({
   "WysylkaZ": TAdres.optional(),
   "WysylkaPrzez": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(TAdres).min(0).max(20)).optional(),
   "WysylkaDo": TAdres.optional()
-})).min(0).max(20)).optional(),
+}).strict()).min(0).max(20)).optional(),
   "PodmiotPosredniczacy": TWybor1.optional()
-}).optional(),
+}).strict().optional(),
   "Zamowienie": z.object({
   "WartoscZamowienia": TKwotowy,
   "ZamowienieWiersz": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
@@ -421,20 +421,20 @@ export const FA2Schema = z.object({
   "ProceduraZ": TOznaczenieProceduryZ.optional(),
   "KwotaAkcyzyZ": TKwotowy.optional(),
   "StanPrzedZ": TWybor1.optional()
-})).min(1).max(10000))
-}).optional()
-}),
+}).strict()).min(1).max(10000))
+}).strict().optional()
+}).strict(),
   "Stopka": z.object({
   "Informacje": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "StopkaFaktury": TTekstowy.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "Rejestry": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "PelnaNazwa": TZnakowy.optional(),
   "KRS": TNrKRS.optional(),
   "REGON": TNrREGON.optional(),
   "BDO": z.string().min(1).max(9).optional()
-})).min(0).max(100)).optional()
-}).optional()
-});
+}).strict()).min(0).max(100)).optional()
+}).strict().optional()
+}).strict();
 
 export type FA2 = z.infer<typeof FA2Schema>;

--- a/src/validation/schemas/fa3.ts
+++ b/src/validation/schemas/fa3.ts
@@ -10,11 +10,11 @@ const TDataCzas = z.string();
 const TZnakowy = z.string().min(1).max(256);
 
 const TNaglowek = z.object({
-  "KodFormularza": z.object({ '#text': TKodFormularza, "@kodSystemowy": z.literal("FA (3)"), "@wersjaSchemy": z.literal("1-0E") }),
+  "KodFormularza": z.object({ '#text': TKodFormularza, "@kodSystemowy": z.literal("FA (3)"), "@wersjaSchemy": z.literal("1-0E") }).strict(),
   "WariantFormularza": z.literal("3"),
   "DataWytworzeniaFa": z.string(),
   "SystemInfo": TZnakowy.optional()
-});
+}).strict();
 
 const TKodyKrajowUE = z.enum(["AT", "BE", "BG", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "EL", "HR", "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK", "SI", "ES", "SE", "XI"]);
 
@@ -25,7 +25,7 @@ const TZnakowy512 = z.string().min(1).max(512);
 const TPodmiot1 = z.object({
   "NIP": TNrNIP,
   "Nazwa": TZnakowy512
-});
+}).strict();
 
 const TKodKraju = z.enum(["AF", "AX", "AL", "DZ", "AD", "AO", "AI", "AQ", "AG", "AN", "SA", "AR", "AM", "AW", "AU", "AT", "AZ", "BS", "BH", "BD", "BB", "BE", "BZ", "BJ", "BM", "BT", "BY", "BO", "BQ", "BA", "BW", "BR", "BN", "IO", "BG", "BF", "BI", "XC", "CL", "CN", "HR", "CW", "CY", "TD", "ME", "DK", "DM", "DO", "DJ", "EG", "EC", "ER", "EE", "ET", "FK", "FJ", "PH", "FI", "FR", "TF", "GA", "GM", "GH", "GI", "GR", "GD", "GL", "GE", "GU", "GG", "GY", "GF", "GP", "GT", "GN", "GQ", "GW", "HT", "ES", "HN", "HK", "IN", "ID", "IQ", "IR", "IE", "IS", "IL", "JM", "JP", "YE", "JE", "JO", "KY", "KH", "CM", "CA", "QA", "KZ", "KE", "KG", "KI", "CO", "KM", "CG", "CD", "KP", "XK", "CR", "CU", "KW", "LA", "LS", "LB", "LR", "LY", "LI", "LT", "LV", "LU", "MK", "MG", "YT", "MO", "MW", "MV", "MY", "ML", "MT", "MP", "MA", "MQ", "MR", "MU", "MX", "XL", "FM", "UM", "MD", "MC", "MN", "MS", "MZ", "MM", "NA", "NR", "NP", "NL", "DE", "NE", "NG", "NI", "NU", "NF", "NO", "NC", "NZ", "PS", "OM", "PK", "PW", "PA", "PG", "PY", "PE", "PN", "PF", "PL", "GS", "PT", "PR", "CF", "CZ", "KR", "ZA", "RE", "RU", "RO", "RW", "EH", "BL", "KN", "LC", "MF", "VC", "SV", "WS", "AS", "SM", "SN", "RS", "SC", "SL", "SG", "SK", "SI", "SO", "LK", "PM", "US", "SZ", "SD", "SS", "SR", "SJ", "SH", "SY", "CH", "SE", "TJ", "TH", "TW", "TZ", "TG", "TK", "TO", "TT", "TN", "TR", "TM", "TV", "UG", "UA", "UY", "UZ", "VU", "WF", "VA", "HU", "VE", "GB", "VN", "IT", "TL", "CI", "BV", "CX", "IM", "SX", "CK", "VI", "VG", "HM", "CC", "MH", "FO", "SB", "ST", "TC", "ZM", "CV", "ZW", "AE", "XI"]);
 
@@ -36,7 +36,7 @@ const TAdres = z.object({
   "AdresL1": TZnakowy512,
   "AdresL2": TZnakowy512.optional(),
   "GLN": TGLN.optional()
-});
+}).strict();
 
 const TAdresEmail = z.string().min(3).max(255).regex(/^(.)+@(.)+$/);
 
@@ -58,7 +58,7 @@ const TPodmiot2 = z.object({
   "NrID": z.string().min(1).max(50).optional(),
   "BrakID": TWybor1.optional(),
   "Nazwa": TZnakowy512.optional()
-});
+}).strict();
 
 const TZnakowy50 = z.string().min(1).max(50);
 
@@ -75,7 +75,7 @@ const TPodmiot3 = z.object({
   "NrID": z.string().min(1).max(50).optional(),
   "BrakID": TWybor1.optional(),
   "Nazwa": TZnakowy512.optional()
-});
+}).strict();
 
 const TRolaPodmiotu3 = z.enum(["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]);
 
@@ -107,7 +107,7 @@ const TKluczWartosc = z.object({
   "NrWiersza": TNaturalny.optional(),
   "Klucz": TZnakowy,
   "Wartosc": TZnakowy
-});
+}).strict();
 
 const TKwotowy2 = z.string().regex(/^-?([1-9]\d{0,13}|0)(\.\d{1,8})?$/);
 
@@ -131,7 +131,7 @@ const TRachunekBankowy = z.object({
   "RachunekWlasnyBanku": TRachunekWlasnyBanku.optional(),
   "NazwaBanku": TZnakowy.optional(),
   "OpisRachunku": TZnakowy.optional()
-});
+}).strict();
 
 const TDataU = z.string();
 
@@ -162,13 +162,13 @@ export const FA3Schema = z.object({
   "AdresL1": TZnakowy512,
   "AdresL2": TZnakowy512.optional(),
   "GLN": TGLN.optional()
-}).optional(),
+}).strict().optional(),
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Email": TAdresEmail.optional(),
   "Telefon": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "StatusInfoPodatnika": TStatusInfoPodatnika.optional()
-}),
+}).strict(),
   "Podmiot2": z.object({
   "NrEORI": TZnakowy.optional(),
   "DaneIdentyfikacyjne": TPodmiot2,
@@ -177,12 +177,12 @@ export const FA3Schema = z.object({
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Email": TAdresEmail.optional(),
   "Telefon": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "NrKlienta": TZnakowy.optional(),
   "IDNabywcy": z.string().min(1).max(32).optional(),
   "JST": z.enum(["1", "2"]),
   "GV": z.enum(["1", "2"])
-}),
+}).strict(),
   "Podmiot3": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "IDNabywcy": z.string().min(1).max(32).optional(),
   "NrEORI": TZnakowy.optional(),
@@ -192,13 +192,13 @@ export const FA3Schema = z.object({
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Email": TAdresEmail.optional(),
   "Telefon": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "Rola": TRolaPodmiotu3.optional(),
   "RolaInna": TWybor1.optional(),
   "OpisRoli": TZnakowy.optional(),
   "Udzial": TProcentowy.optional(),
   "NrKlienta": TZnakowy.optional()
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "PodmiotUpowazniony": z.object({
   "NrEORI": TZnakowy.optional(),
   "DaneIdentyfikacyjne": TPodmiot1,
@@ -207,9 +207,9 @@ export const FA3Schema = z.object({
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "EmailPU": TAdresEmail.optional(),
   "TelefonPU": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "RolaPU": TRolaPodmiotuUpowaznionego
-}).optional(),
+}).strict().optional(),
   "Fa": z.object({
   "KodWaluty": TKodWaluty,
   "P_1": TDataT,
@@ -220,7 +220,7 @@ export const FA3Schema = z.object({
   "OkresFa": z.object({
   "P_6_Od": TDataT,
   "P_6_Do": TDataT
-}).optional(),
+}).strict().optional(),
   "P_13_1": TKwotowy.optional(),
   "P_14_1": TKwotowy.optional(),
   "P_14_1W": TKwotowy.optional(),
@@ -250,7 +250,7 @@ export const FA3Schema = z.object({
   "P_17": TWybor1_2,
   "P_18": TWybor1_2,
   "P_18A": TWybor1_2,
-  "Zwolnienie": z.union([z.object({ "P_19": TWybor1, "P_19A": TZnakowy.optional(), "P_19B": TZnakowy.optional(), "P_19C": TZnakowy.optional() }), z.object({ "P_19N": TWybor1 })]),
+  "Zwolnienie": z.union([z.object({ "P_19": TWybor1, "P_19A": TZnakowy.optional(), "P_19B": TZnakowy.optional(), "P_19C": TZnakowy.optional() }).strict(), z.object({ "P_19N": TWybor1 }).strict()]),
   "NoweSrodkiTransportu": z.union([z.object({ "P_22": TWybor1, "P_42_5": TWybor1_2, "NowySrodekTransportu": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "P_22A": TDataT,
   "P_NrWierszaNST": TNaturalny,
@@ -269,10 +269,10 @@ export const FA3Schema = z.object({
   "P_22C1": TZnakowy.optional(),
   "P_22D": TZnakowy.optional(),
   "P_22D1": TZnakowy.optional()
-})).min(1).max(10000)) }), z.object({ "P_22N": TWybor1 })]),
+}).strict()).min(1).max(10000)) }).strict(), z.object({ "P_22N": TWybor1 }).strict()]),
   "P_23": TWybor1_2,
-  "PMarzy": z.union([z.object({ "P_PMarzy": TWybor1, "P_PMarzy_2": TWybor1.optional(), "P_PMarzy_3_1": TWybor1.optional(), "P_PMarzy_3_2": TWybor1.optional(), "P_PMarzy_3_3": TWybor1.optional() }), z.object({ "P_PMarzyN": TWybor1 })])
-}),
+  "PMarzy": z.union([z.object({ "P_PMarzy": TWybor1, "P_PMarzy_2": TWybor1.optional(), "P_PMarzy_3_1": TWybor1.optional(), "P_PMarzy_3_2": TWybor1.optional(), "P_PMarzy_3_3": TWybor1.optional() }).strict(), z.object({ "P_PMarzyN": TWybor1 }).strict()])
+}).strict(),
   "RodzajFaktury": TRodzajFaktury,
   "PrzyczynaKorekty": TZnakowy.optional(),
   "TypKorekty": TTypKorekty.optional(),
@@ -282,30 +282,30 @@ export const FA3Schema = z.object({
   "NrKSeF": TWybor1.optional(),
   "NrKSeFFaKorygowanej": TNumerKSeF.optional(),
   "NrKSeFN": TWybor1.optional()
-})).min(1).max(50000)).optional(),
+}).strict()).min(1).max(50000)).optional(),
   "OkresFaKorygowanej": TZnakowy.optional(),
   "NrFaKorygowany": TZnakowy.optional(),
   "Podmiot1K": z.object({
   "PrefiksPodatnika": TKodyKrajowUE.optional(),
   "DaneIdentyfikacyjne": TPodmiot1,
   "Adres": TAdres
-}).optional(),
+}).strict().optional(),
   "Podmiot2K": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "DaneIdentyfikacyjne": TPodmiot2,
   "Adres": TAdres.optional(),
   "IDNabywcy": z.string().min(1).max(32).optional()
-})).min(0).max(101)).optional(),
+}).strict()).min(0).max(101)).optional(),
   "P_15ZK": TKwotowy.optional(),
   "KursWalutyZK": TIlosci.optional(),
   "ZaliczkaCzesciowa": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "P_6Z": TDataT,
   "P_15Z": TKwotowy,
   "KursWalutyZW": TIlosci.optional()
-})).min(0).max(31)).optional(),
+}).strict()).min(0).max(31)).optional(),
   "FP": TWybor1.optional(),
   "TP": TWybor1.optional(),
   "DodatkowyOpis": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(TKluczWartosc).min(0).max(10000)).optional(),
-  "FakturaZaliczkowa": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.union([z.object({ "NrKSeFZN": TWybor1, "NrFaZaliczkowej": TZnakowy }), z.object({ "NrKSeFFaZaliczkowej": TNumerKSeF })])).min(0).max(100)).optional(),
+  "FakturaZaliczkowa": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.union([z.object({ "NrKSeFZN": TWybor1, "NrFaZaliczkowej": TZnakowy }).strict(), z.object({ "NrKSeFFaZaliczkowej": TNumerKSeF }).strict()])).min(0).max(100)).optional(),
   "ZwrotAkcyzy": TWybor1.optional(),
   "FaWiersz": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "NrWierszaFa": TNaturalny,
@@ -333,21 +333,21 @@ export const FA3Schema = z.object({
   "Procedura": TOznaczenieProcedury.optional(),
   "KursWaluty": TIlosci.optional(),
   "StanPrzed": TWybor1.optional()
-})).min(0).max(10000)).optional(),
+}).strict()).min(0).max(10000)).optional(),
   "Rozliczenie": z.object({
   "Obciazenia": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Kwota": TKwotowy,
   "Powod": TZnakowy
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "SumaObciazen": TKwotowy.optional(),
   "Odliczenia": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Kwota": TKwotowy,
   "Powod": TZnakowy
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "SumaOdliczen": TKwotowy.optional(),
   "DoZaplaty": TKwotowy.optional(),
   "DoRozliczenia": TKwotowy.optional()
-}).optional(),
+}).strict().optional(),
   "Platnosc": z.object({
   "Zaplacono": TWybor1.optional(),
   "DataZaplaty": TData.optional(),
@@ -358,15 +358,15 @@ export const FA3Schema = z.object({
   "FormaPlatnosci": TFormaPlatnosci.optional(),
   "PlatnoscInna": TWybor1.optional(),
   "OpisPlatnosci": TZnakowy.optional()
-})).min(1).max(100)).optional(),
+}).strict()).min(1).max(100)).optional(),
   "TerminPlatnosci": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Termin": TData.optional(),
   "TerminOpis": z.object({
   "Ilosc": z.coerce.number().int(),
   "Jednostka": TZnakowy50,
   "ZdarzeniePoczatkowe": TZnakowy
-}).optional()
-})).min(0).max(100)).optional(),
+}).strict().optional()
+}).strict()).min(0).max(100)).optional(),
   "FormaPlatnosci": TFormaPlatnosci.optional(),
   "PlatnoscInna": TWybor1.optional(),
   "OpisPlatnosci": TZnakowy.optional(),
@@ -375,19 +375,19 @@ export const FA3Schema = z.object({
   "Skonto": z.object({
   "WarunkiSkonta": TZnakowy,
   "WysokoscSkonta": TZnakowy
-}).optional(),
+}).strict().optional(),
   "LinkDoPlatnosci": z.string().min(1).max(512).regex(/^(https?):\/\/([a-zA-Z0-9][a-zA-Z0-9-]*\.)+[a-zA-Z]{2,}(:[0-9]{1,5})?(\/[^\s?#]*)?\?([^#\s]*&)?IPKSeF=[0-9]{3}[a-zA-Z0-9]{10}(&[^#\s]*)?(#.*)?$/).optional(),
   "IPKSeF": z.string().min(1).max(13).regex(/^[0-9]{3}[a-zA-Z0-9]{10}$/).optional()
-}).optional(),
+}).strict().optional(),
   "WarunkiTransakcji": z.object({
   "Umowy": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "DataUmowy": TDataU.optional(),
   "NrUmowy": TZnakowy.optional()
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "Zamowienia": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "DataZamowienia": TDataU.optional(),
   "NrZamowienia": TZnakowy.optional()
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "NrPartiiTowaru": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(TZnakowy).min(0).max(1000)).optional(),
   "WarunkiDostawy": TZnakowy.optional(),
   "KursUmowny": TIlosci.optional(),
@@ -399,7 +399,7 @@ export const FA3Schema = z.object({
   "Przewoznik": z.object({
   "DaneIdentyfikacyjne": TPodmiot2,
   "AdresPrzewoznika": TAdres
-}).optional(),
+}).strict().optional(),
   "NrZleceniaTransportu": TZnakowy.optional(),
   "OpisLadunku": TLadunek.optional(),
   "LadunekInny": TWybor1.optional(),
@@ -410,9 +410,9 @@ export const FA3Schema = z.object({
   "WysylkaZ": TAdres.optional(),
   "WysylkaPrzez": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(TAdres).min(0).max(20)).optional(),
   "WysylkaDo": TAdres.optional()
-})).min(0).max(20)).optional(),
+}).strict()).min(0).max(20)).optional(),
   "PodmiotPosredniczacy": TWybor1.optional()
-}).optional(),
+}).strict().optional(),
   "Zamowienie": z.object({
   "WartoscZamowienia": TKwotowy,
   "ZamowienieWiersz": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
@@ -436,23 +436,23 @@ export const FA3Schema = z.object({
   "ProceduraZ": TOznaczenieProceduryZ.optional(),
   "KwotaAkcyzyZ": TKwotowy.optional(),
   "StanPrzedZ": TWybor1.optional()
-})).min(1).max(10000))
-}).optional()
-}),
+}).strict()).min(1).max(10000))
+}).strict().optional()
+}).strict(),
   "Stopka": z.object({
   "Informacje": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "StopkaFaktury": TTekstowy.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "Rejestry": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "PelnaNazwa": TZnakowy.optional(),
   "KRS": TNrKRS.optional(),
   "REGON": TNrREGON.optional(),
   "BDO": z.string().min(1).max(9).optional()
-})).min(0).max(100)).optional()
-}).optional(),
+}).strict()).min(0).max(100)).optional()
+}).strict().optional(),
   "Zalacznik": z.object({
   "BlokDanych": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.any()).min(1).max(1000))
-}).optional()
-});
+}).strict().optional()
+}).strict();
 
 export type FA3 = z.infer<typeof FA3Schema>;

--- a/src/validation/schemas/pef-kor3.ts
+++ b/src/validation/schemas/pef-kor3.ts
@@ -55,7 +55,7 @@ const CreditNoteType = z.object({
   "TaxTotal": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.any()).min(0)).optional(),
   "LegalMonetaryTotal": z.any(),
   "CreditNoteLine": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.any()).min(1))
-});
+}).strict();
 
 
 export const PEF_KOR3Schema = CreditNoteType;

--- a/src/validation/schemas/pef3.ts
+++ b/src/validation/schemas/pef3.ts
@@ -58,7 +58,7 @@ const InvoiceType = z.object({
   "WithholdingTaxTotal": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.any()).min(0)).optional(),
   "LegalMonetaryTotal": z.any(),
   "InvoiceLine": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.any()).min(1))
-});
+}).strict();
 
 
 export const PEF3Schema = InvoiceType;

--- a/src/validation/schemas/rr1-v10e.ts
+++ b/src/validation/schemas/rr1-v10e.ts
@@ -10,11 +10,11 @@ const TDataCzas = z.string();
 const TZnakowy = z.string().min(1).max(256);
 
 const TNaglowek = z.object({
-  "KodFormularza": z.object({ '#text': TKodFormularza, "@kodSystemowy": z.literal("FA_RR(1)"), "@wersjaSchemy": z.literal("1-0E") }),
+  "KodFormularza": z.object({ '#text': TKodFormularza, "@kodSystemowy": z.literal("FA_RR(1)"), "@wersjaSchemy": z.literal("1-0E") }).strict(),
   "WariantFormularza": z.literal("1"),
   "DataWytworzeniaFa": z.string(),
   "SystemInfo": TZnakowy.optional()
-});
+}).strict();
 
 const TNrNIP = z.string().regex(/^[1-9]((\d[1-9])|([1-9]\d))\d{7}$/);
 
@@ -23,7 +23,7 @@ const TZnakowy512 = z.string().min(1).max(512);
 const TPodmiot1 = z.object({
   "NIP": TNrNIP,
   "Nazwa": TZnakowy512
-});
+}).strict();
 
 const TKodKraju = z.enum(["AF", "AX", "AL", "DZ", "AD", "AO", "AI", "AQ", "AG", "AN", "SA", "AR", "AM", "AW", "AU", "AT", "AZ", "BS", "BH", "BD", "BB", "BE", "BZ", "BJ", "BM", "BT", "BY", "BO", "BQ", "BA", "BW", "BR", "BN", "IO", "BG", "BF", "BI", "XC", "CL", "CN", "HR", "CW", "CY", "TD", "ME", "DK", "DM", "DO", "DJ", "EG", "EC", "ER", "EE", "ET", "FK", "FJ", "PH", "FI", "FR", "TF", "GA", "GM", "GH", "GI", "GR", "GD", "GL", "GE", "GU", "GG", "GY", "GF", "GP", "GT", "GN", "GQ", "GW", "HT", "ES", "HN", "HK", "IN", "ID", "IQ", "IR", "IE", "IS", "IL", "JM", "JP", "YE", "JE", "JO", "KY", "KH", "CM", "CA", "QA", "KZ", "KE", "KG", "KI", "CO", "KM", "CG", "CD", "KP", "XK", "CR", "CU", "KW", "LA", "LS", "LB", "LR", "LY", "LI", "LT", "LV", "LU", "MK", "MG", "YT", "MO", "MW", "MV", "MY", "ML", "MT", "MP", "MA", "MQ", "MR", "MU", "MX", "XL", "FM", "UM", "MD", "MC", "MN", "MS", "MZ", "MM", "NA", "NR", "NP", "NL", "DE", "NE", "NG", "NI", "NU", "NF", "NO", "NC", "NZ", "PS", "OM", "PK", "PW", "PA", "PG", "PY", "PE", "PN", "PF", "PL", "GS", "PT", "PR", "CF", "CZ", "KR", "ZA", "RE", "RU", "RO", "RW", "EH", "BL", "KN", "LC", "MF", "VC", "SV", "WS", "AS", "SM", "SN", "RS", "SC", "SL", "SG", "SK", "SI", "SO", "LK", "PM", "US", "SZ", "SD", "SS", "SR", "SJ", "SH", "SY", "CH", "SE", "TJ", "TH", "TW", "TZ", "TG", "TK", "TO", "TT", "TN", "TR", "TM", "TV", "UG", "UA", "UY", "UZ", "VU", "WF", "VA", "HU", "VE", "GB", "VN", "IT", "TL", "CI", "BV", "CX", "IM", "SX", "CK", "VI", "VG", "HM", "CC", "MH", "FO", "SB", "ST", "TC", "ZM", "CV", "ZW", "AE", "XI"]);
 
@@ -34,7 +34,7 @@ const TAdres = z.object({
   "AdresL1": TZnakowy512,
   "AdresL2": TZnakowy512.optional(),
   "GLN": TGLN.optional()
-});
+}).strict();
 
 const TAdresEmail = z.string().min(3).max(255).regex(/^(.)+@(.)+$/);
 
@@ -53,7 +53,7 @@ const TPodmiot3 = z.object({
   "IDWew": TNIPIdWew.optional(),
   "BrakID": TWybor1.optional(),
   "Nazwa": TZnakowy512
-});
+}).strict();
 
 const TRolaPodmiotu3 = z.enum(["1", "2", "3", "5", "6", "7", "8", "9", "10", "11"]);
 
@@ -77,7 +77,7 @@ const TKluczWartosc = z.object({
   "NrWiersza": TNaturalny.optional(),
   "Klucz": TZnakowy,
   "Wartosc": TZnakowy
-});
+}).strict();
 
 const TZnakowy50 = z.string().min(1).max(50);
 
@@ -100,7 +100,7 @@ const TRachunekBankowy = z.object({
   "SWIFT": SWIFT_Type.optional(),
   "NazwaBanku": TZnakowy.optional(),
   "OpisRachunku": TZnakowy.optional()
-});
+}).strict();
 
 const TTekstowy = z.string().min(1).max(3500);
 
@@ -118,9 +118,9 @@ export const RR1_V10ESchema = z.object({
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Email": TAdresEmail.optional(),
   "Telefon": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "NrKontrahenta": TZnakowy.optional()
-}),
+}).strict(),
   "Podmiot2": z.object({
   "DaneIdentyfikacyjne": TPodmiot1,
   "Adres": TAdres,
@@ -128,9 +128,9 @@ export const RR1_V10ESchema = z.object({
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Email": TAdresEmail.optional(),
   "Telefon": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "StatusInfoPodatnika": TStatusInfoPodatnika.optional()
-}),
+}).strict(),
   "Podmiot3": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "DaneIdentyfikacyjne": TPodmiot3,
   "Adres": TAdres.optional(),
@@ -138,11 +138,11 @@ export const RR1_V10ESchema = z.object({
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Email": TAdresEmail.optional(),
   "Telefon": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "Rola": TRolaPodmiotu3.optional(),
   "RolaInna": TWybor1.optional(),
   "OpisRoli": TZnakowy.optional()
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "FakturaRR": z.object({
   "KodWaluty": TKodWaluty,
   "P_1M": TZnakowy.optional(),
@@ -165,20 +165,20 @@ export const RR1_V10ESchema = z.object({
   "NrKSeF": TWybor1.optional(),
   "NrKSeFFaKorygowanej": TNumerKSeF.optional(),
   "NrKSeFN": TWybor1.optional()
-})).min(1).max(50000)).optional(),
+}).strict()).min(1).max(50000)).optional(),
   "NrFaKorygowany": TZnakowy.optional(),
   "Podmiot1K": z.object({
   "DaneIdentyfikacyjne": TPodmiot1,
   "Adres": TAdres
-}).optional(),
+}).strict().optional(),
   "Podmiot2K": z.object({
   "DaneIdentyfikacyjne": TPodmiot1,
   "Adres": TAdres
-}).optional(),
+}).strict().optional(),
   "DokumentZaplaty": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "NrDokumentu": TZnakowy,
   "DataDokumentu": TData.optional()
-})).min(0).max(50)).optional(),
+}).strict()).min(0).max(50)).optional(),
   "DodatkowyOpis": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(TKluczWartosc).min(0).max(10000)).optional(),
   "FakturaRRWiersz": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "NrWierszaFa": TNaturalny,
@@ -198,21 +198,21 @@ export const RR1_V10ESchema = z.object({
   "P_11": TKwotowy,
   "StanPrzed": TWybor1.optional(),
   "KursWaluty": TIlosci.optional()
-})).min(0).max(10000)).optional(),
+}).strict()).min(0).max(10000)).optional(),
   "Rozliczenie": z.object({
   "Obciazenia": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Kwota": TKwotowy,
   "Powod": TZnakowy
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "SumaObciazen": TKwotowy.optional(),
   "Odliczenia": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Kwota": TKwotowy,
   "Powod": TZnakowy
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "SumaOdliczen": TKwotowy.optional(),
   "DoZaplaty": TKwotowy.optional(),
   "DoRozliczenia": TKwotowy.optional()
-}).optional(),
+}).strict().optional(),
   "Platnosc": z.object({
   "FormaPlatnosci": TFormaPlatnosci.optional(),
   "PlatnoscInna": TWybor1.optional(),
@@ -221,19 +221,19 @@ export const RR1_V10ESchema = z.object({
   "RachunekBankowy2": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(TRachunekBankowy).min(0).max(3)).optional(),
   "IPKSeF": z.string().min(1).max(13).regex(/^[0-9]{3}[a-zA-Z0-9]{10}$/).optional(),
   "LinkDoPlatnosci": z.string().min(1).max(512).regex(/^(https?):\/\/([a-zA-Z0-9][a-zA-Z0-9-]*\.)+[a-zA-Z]{2,}(:[0-9]{1,5})?(\/[^\s?#]*)?\?([^#\s]*&)?IPKSeF=[0-9]{3}[a-zA-Z0-9]{10}(&[^#\s]*)?(#.*)?$/).optional()
-}).optional()
-}),
+}).strict().optional()
+}).strict(),
   "Stopka": z.object({
   "Informacje": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "StopkaFaktury": TTekstowy.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "Rejestry": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "PelnaNazwa": TZnakowy.optional(),
   "KRS": TNrKRS.optional(),
   "REGON": TNrREGON.optional(),
   "BDO": z.string().min(1).max(9).optional()
-})).min(0).max(100)).optional()
-}).optional()
-});
+}).strict()).min(0).max(100)).optional()
+}).strict().optional()
+}).strict();
 
 export type RR1_V10E = z.infer<typeof RR1_V10ESchema>;

--- a/src/validation/schemas/rr1-v11e.ts
+++ b/src/validation/schemas/rr1-v11e.ts
@@ -10,11 +10,11 @@ const TDataCzas = z.string();
 const TZnakowy = z.string().min(1).max(256);
 
 const TNaglowek = z.object({
-  "KodFormularza": z.object({ '#text': TKodFormularza, "@kodSystemowy": z.literal("FA_RR (1)"), "@wersjaSchemy": z.literal("1-1E") }),
+  "KodFormularza": z.object({ '#text': TKodFormularza, "@kodSystemowy": z.literal("FA_RR (1)"), "@wersjaSchemy": z.literal("1-1E") }).strict(),
   "WariantFormularza": z.literal("1"),
   "DataWytworzeniaFa": z.string(),
   "SystemInfo": TZnakowy.optional()
-});
+}).strict();
 
 const TNrNIP = z.string().regex(/^[1-9]((\d[1-9])|([1-9]\d))\d{7}$/);
 
@@ -23,7 +23,7 @@ const TZnakowy512 = z.string().min(1).max(512);
 const TPodmiot1 = z.object({
   "NIP": TNrNIP,
   "Nazwa": TZnakowy512
-});
+}).strict();
 
 const TKodKraju = z.enum(["AF", "AX", "AL", "DZ", "AD", "AO", "AI", "AQ", "AG", "AN", "SA", "AR", "AM", "AW", "AU", "AT", "AZ", "BS", "BH", "BD", "BB", "BE", "BZ", "BJ", "BM", "BT", "BY", "BO", "BQ", "BA", "BW", "BR", "BN", "IO", "BG", "BF", "BI", "XC", "CL", "CN", "HR", "CW", "CY", "TD", "ME", "DK", "DM", "DO", "DJ", "EG", "EC", "ER", "EE", "ET", "FK", "FJ", "PH", "FI", "FR", "TF", "GA", "GM", "GH", "GI", "GR", "GD", "GL", "GE", "GU", "GG", "GY", "GF", "GP", "GT", "GN", "GQ", "GW", "HT", "ES", "HN", "HK", "IN", "ID", "IQ", "IR", "IE", "IS", "IL", "JM", "JP", "YE", "JE", "JO", "KY", "KH", "CM", "CA", "QA", "KZ", "KE", "KG", "KI", "CO", "KM", "CG", "CD", "KP", "XK", "CR", "CU", "KW", "LA", "LS", "LB", "LR", "LY", "LI", "LT", "LV", "LU", "MK", "MG", "YT", "MO", "MW", "MV", "MY", "ML", "MT", "MP", "MA", "MQ", "MR", "MU", "MX", "XL", "FM", "UM", "MD", "MC", "MN", "MS", "MZ", "MM", "NA", "NR", "NP", "NL", "DE", "NE", "NG", "NI", "NU", "NF", "NO", "NC", "NZ", "PS", "OM", "PK", "PW", "PA", "PG", "PY", "PE", "PN", "PF", "PL", "GS", "PT", "PR", "CF", "CZ", "KR", "ZA", "RE", "RU", "RO", "RW", "EH", "BL", "KN", "LC", "MF", "VC", "SV", "WS", "AS", "SM", "SN", "RS", "SC", "SL", "SG", "SK", "SI", "SO", "LK", "PM", "US", "SZ", "SD", "SS", "SR", "SJ", "SH", "SY", "CH", "SE", "TJ", "TH", "TW", "TZ", "TG", "TK", "TO", "TT", "TN", "TR", "TM", "TV", "UG", "UA", "UY", "UZ", "VU", "WF", "VA", "HU", "VE", "GB", "VN", "IT", "TL", "CI", "BV", "CX", "IM", "SX", "CK", "VI", "VG", "HM", "CC", "MH", "FO", "SB", "ST", "TC", "ZM", "CV", "ZW", "AE", "XI"]);
 
@@ -34,7 +34,7 @@ const TAdres = z.object({
   "AdresL1": TZnakowy512,
   "AdresL2": TZnakowy512.optional(),
   "GLN": TGLN.optional()
-});
+}).strict();
 
 const TAdresEmail = z.string().min(3).max(255).regex(/^(.)+@(.)+$/);
 
@@ -53,7 +53,7 @@ const TPodmiot3 = z.object({
   "IDWew": TNIPIdWew.optional(),
   "BrakID": TWybor1.optional(),
   "Nazwa": TZnakowy512
-});
+}).strict();
 
 const TRolaPodmiotu3 = z.enum(["1", "2", "3", "5", "6", "7", "8", "9", "10", "11"]);
 
@@ -77,7 +77,7 @@ const TKluczWartosc = z.object({
   "NrWiersza": TNaturalny.optional(),
   "Klucz": TZnakowy,
   "Wartosc": TZnakowy
-});
+}).strict();
 
 const TZnakowy50 = z.string().min(1).max(50);
 
@@ -100,7 +100,7 @@ const TRachunekBankowy = z.object({
   "SWIFT": SWIFT_Type.optional(),
   "NazwaBanku": TZnakowy.optional(),
   "OpisRachunku": TZnakowy.optional()
-});
+}).strict();
 
 const TTekstowy = z.string().min(1).max(3500);
 
@@ -118,9 +118,9 @@ export const RR1_V11ESchema = z.object({
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Email": TAdresEmail.optional(),
   "Telefon": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "NrKontrahenta": TZnakowy.optional()
-}),
+}).strict(),
   "Podmiot2": z.object({
   "DaneIdentyfikacyjne": TPodmiot1,
   "Adres": TAdres,
@@ -128,9 +128,9 @@ export const RR1_V11ESchema = z.object({
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Email": TAdresEmail.optional(),
   "Telefon": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "StatusInfoPodatnika": TStatusInfoPodatnika.optional()
-}),
+}).strict(),
   "Podmiot3": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "DaneIdentyfikacyjne": TPodmiot3,
   "Adres": TAdres.optional(),
@@ -138,11 +138,11 @@ export const RR1_V11ESchema = z.object({
   "DaneKontaktowe": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Email": TAdresEmail.optional(),
   "Telefon": TNumerTelefonu.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "Rola": TRolaPodmiotu3.optional(),
   "RolaInna": TWybor1.optional(),
   "OpisRoli": TZnakowy.optional()
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "FakturaRR": z.object({
   "KodWaluty": TKodWaluty,
   "P_1M": TZnakowy.optional(),
@@ -165,20 +165,20 @@ export const RR1_V11ESchema = z.object({
   "NrKSeF": TWybor1.optional(),
   "NrKSeFFaKorygowanej": TNumerKSeF.optional(),
   "NrKSeFN": TWybor1.optional()
-})).min(1).max(50000)).optional(),
+}).strict()).min(1).max(50000)).optional(),
   "NrFaKorygowany": TZnakowy.optional(),
   "Podmiot1K": z.object({
   "DaneIdentyfikacyjne": TPodmiot1,
   "Adres": TAdres
-}).optional(),
+}).strict().optional(),
   "Podmiot2K": z.object({
   "DaneIdentyfikacyjne": TPodmiot1,
   "Adres": TAdres
-}).optional(),
+}).strict().optional(),
   "DokumentZaplaty": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "NrDokumentu": TZnakowy,
   "DataDokumentu": TData.optional()
-})).min(0).max(50)).optional(),
+}).strict()).min(0).max(50)).optional(),
   "DodatkowyOpis": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(TKluczWartosc).min(0).max(10000)).optional(),
   "FakturaRRWiersz": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "NrWierszaFa": TNaturalny,
@@ -198,21 +198,21 @@ export const RR1_V11ESchema = z.object({
   "P_11": TKwotowy,
   "StanPrzed": TWybor1.optional(),
   "KursWaluty": TIlosci.optional()
-})).min(0).max(10000)).optional(),
+}).strict()).min(0).max(10000)).optional(),
   "Rozliczenie": z.object({
   "Obciazenia": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Kwota": TKwotowy,
   "Powod": TZnakowy
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "SumaObciazen": TKwotowy.optional(),
   "Odliczenia": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "Kwota": TKwotowy,
   "Powod": TZnakowy
-})).min(0).max(100)).optional(),
+}).strict()).min(0).max(100)).optional(),
   "SumaOdliczen": TKwotowy.optional(),
   "DoZaplaty": TKwotowy.optional(),
   "DoRozliczenia": TKwotowy.optional()
-}).optional(),
+}).strict().optional(),
   "Platnosc": z.object({
   "FormaPlatnosci": TFormaPlatnosci.optional(),
   "PlatnoscInna": TWybor1.optional(),
@@ -221,19 +221,19 @@ export const RR1_V11ESchema = z.object({
   "RachunekBankowy2": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(TRachunekBankowy).min(0).max(3)).optional(),
   "IPKSeF": z.string().min(1).max(13).regex(/^[0-9]{3}[a-zA-Z0-9]{10}$/).optional(),
   "LinkDoPlatnosci": z.string().min(1).max(512).regex(/^(https?):\/\/([a-zA-Z0-9][a-zA-Z0-9-]*\.)+[a-zA-Z]{2,}(:[0-9]{1,5})?(\/[^\s?#]*)?\?([^#\s]*&)?IPKSeF=[0-9]{3}[a-zA-Z0-9]{10}(&[^#\s]*)?(#.*)?$/).optional()
-}).optional()
-}),
+}).strict().optional()
+}).strict(),
   "Stopka": z.object({
   "Informacje": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "StopkaFaktury": TTekstowy.optional()
-})).min(0).max(3)).optional(),
+}).strict()).min(0).max(3)).optional(),
   "Rejestry": z.preprocess(v => Array.isArray(v) ? v : v == null ? [] : [v], z.array(z.object({
   "PelnaNazwa": TZnakowy.optional(),
   "KRS": TNrKRS.optional(),
   "REGON": TNrREGON.optional(),
   "BDO": z.string().min(1).max(9).optional()
-})).min(0).max(100)).optional()
-}).optional()
-});
+}).strict()).min(0).max(100)).optional()
+}).strict().optional()
+}).strict();
 
 export type RR1_V11E = z.infer<typeof RR1_V11ESchema>;

--- a/src/workflows/batch-session-workflow.ts
+++ b/src/workflows/batch-session-workflow.ts
@@ -29,22 +29,20 @@ export async function uploadBatch(
 
   if (options?.validate) {
     const { unzip } = await import('../utils/zip.js');
-    const { validateBatch } = await import('../validation/invoice-validator.js');
+    const { validateBatch, batchValidationDetails } = await import('../validation/invoice-validator.js');
     const { KSeFValidationError } = await import('../errors/ksef-validation-error.js');
-    const files = await unzip(Buffer.from(zipData));
+    const zipBuf = Buffer.isBuffer(zipData) ? zipData : Buffer.from(zipData.buffer, zipData.byteOffset, zipData.byteLength);
+    const files = await unzip(zipBuf);
     const invoices = [...files.entries()]
       .filter(([name]) => name.endsWith('.xml'))
       .map(([name, data]) => ({ fileName: name, xml: data.toString('utf-8') }));
     if (invoices.length > 0) {
       const result = await validateBatch(invoices);
       if (!result.valid) {
-        const invalid = result.results.filter(r => !r.result.valid);
+        const invalidCount = result.results.filter(r => !r.result.valid).length;
         throw new KSeFValidationError(
-          `Batch validation failed: ${invalid.length} of ${invoices.length} invoices invalid`,
-          invalid.flatMap(r => r.result.errors.map(e => ({
-            field: `${r.fileName}:${e.path ?? ''}`,
-            message: e.message,
-          }))),
+          `Batch validation failed: ${invalidCount} of ${invoices.length} invoices invalid`,
+          batchValidationDetails(result),
         );
       }
     }

--- a/src/workflows/batch-session-workflow.ts
+++ b/src/workflows/batch-session-workflow.ts
@@ -16,6 +16,8 @@ export interface BatchUploadOptions {
   maxPartSize?: number;
   /** Pass-through to KSeF API. */
   offlineMode?: boolean;
+  /** Validate each invoice XML in the ZIP before uploading. */
+  validate?: boolean;
 }
 
 export async function uploadBatch(
@@ -24,6 +26,30 @@ export async function uploadBatch(
   options?: BatchUploadOptions,
 ): Promise<BatchUploadResult> {
   await client.crypto.init();
+
+  if (options?.validate) {
+    const { unzip } = await import('../utils/zip.js');
+    const { validateBatch } = await import('../validation/invoice-validator.js');
+    const { KSeFValidationError } = await import('../errors/ksef-validation-error.js');
+    const files = await unzip(Buffer.from(zipData));
+    const invoices = [...files.entries()]
+      .filter(([name]) => name.endsWith('.xml'))
+      .map(([name, data]) => ({ fileName: name, xml: data.toString('utf-8') }));
+    if (invoices.length > 0) {
+      const result = await validateBatch(invoices);
+      if (!result.valid) {
+        const invalid = result.results.filter(r => !r.result.valid);
+        throw new KSeFValidationError(
+          `Batch validation failed: ${invalid.length} of ${invoices.length} invoices invalid`,
+          invalid.flatMap(r => r.result.errors.map(e => ({
+            field: `${r.fileName}:${e.path ?? ''}`,
+            message: e.message,
+          }))),
+        );
+      }
+    }
+  }
+
   const encData = client.crypto.getEncryptionData();
   const formCode = options?.formCode ?? DEFAULT_FORM_CODE;
 

--- a/tests/fixtures/invoices/invalid-unknown-element-in-fawiersz-fa3.xml
+++ b/tests/fixtures/invoices/invalid-unknown-element-in-fawiersz-fa3.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Faktura
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:etd="http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/"
+		xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+	<Naglowek>
+		<KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+		<WariantFormularza>3</WariantFormularza>
+		<DataWytworzeniaFa>2026-01-15T12:00:00Z</DataWytworzeniaFa>
+		<SystemInfo>test-system</SystemInfo>
+	</Naglowek>
+	<Podmiot1>
+		<PrefiksPodatnika>PL</PrefiksPodatnika>
+		<DaneIdentyfikacyjne>
+			<NIP>1111111111</NIP>
+			<Nazwa>Test Seller Sp. z o.o.</Nazwa>
+		</DaneIdentyfikacyjne>
+		<Adres>
+			<KodKraju>PL</KodKraju>
+			<AdresL1>ul. Testowa 1</AdresL1>
+			<AdresL2>00-001 Warszawa</AdresL2>
+		</Adres>
+	</Podmiot1>
+	<Podmiot2>
+		<DaneIdentyfikacyjne>
+			<BrakID>1</BrakID>
+			<Nazwa>Test Buyer Inc.</Nazwa>
+		</DaneIdentyfikacyjne>
+		<Adres>
+			<KodKraju>US</KodKraju>
+			<AdresL1>123 Test Street</AdresL1>
+			<AdresL2>New York, NY 10001</AdresL2>
+		</Adres>
+		<JST>2</JST>
+		<GV>2</GV>
+	</Podmiot2>
+	<Fa>
+		<KodWaluty>EUR</KodWaluty>
+		<P_1>2026-01-15</P_1>
+		<P_1M>Warszawa</P_1M>
+		<P_2>TEST/2026/001</P_2>
+		<P_6>2026-01-15</P_6>
+		<P_13_8>1000.00</P_13_8>
+		<P_15>1000.00</P_15>
+		<Adnotacje>
+			<P_16>2</P_16>
+			<P_17>2</P_17>
+			<P_18>2</P_18>
+			<P_18A>2</P_18A>
+			<Zwolnienie>
+				<P_19N>1</P_19N>
+			</Zwolnienie>
+			<NoweSrodkiTransportu>
+				<P_22N>1</P_22N>
+			</NoweSrodkiTransportu>
+			<P_23>2</P_23>
+			<PMarzy>
+				<P_PMarzyN>1</P_PMarzyN>
+			</PMarzy>
+		</Adnotacje>
+		<RodzajFaktury>VAT</RodzajFaktury>
+		<DodatkowyOpis>
+			<Klucz>Reverse charge</Klucz>
+			<Wartosc>Art. 28b - not subject to Polish VAT</Wartosc>
+		</DodatkowyOpis>
+		<FaWiersz>
+			<NrWierszaFa>1</NrWierszaFa>
+			<P_7>Consulting services</P_7>
+			<P_8A>h</P_8A>
+			<P_8B>100</P_8B>
+			<P_9A>10.00</P_9A>
+			<P_11>1000.00</P_11>
+			<P_12>np I</P_12>
+			<DodatkowyOpis>
+				<Klucz>Note</Klucz>
+				<Wartosc>This element is invalid inside FaWiersz - should be rejected by validator</Wartosc>
+			</DodatkowyOpis>
+		</FaWiersz>
+		<Platnosc>
+			<TerminPlatnosci>
+				<Termin>2026-02-15</Termin>
+			</TerminPlatnosci>
+			<FormaPlatnosci>6</FormaPlatnosci>
+			<RachunekBankowy>
+				<NrRB>PL00000000000000000000000000</NrRB>
+				<SWIFT>TESTPLPW</SWIFT>
+				<NazwaBanku>Test Bank S.A.</NazwaBanku>
+			</RachunekBankowy>
+		</Platnosc>
+	</Fa>
+</Faktura>

--- a/tests/fixtures/invoices/valid-fa2.xml
+++ b/tests/fixtures/invoices/valid-fa2.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Faktura xmlns="http://crd.gov.pl/wzor/2023/06/29/12648/"
+         xmlns:etd="http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (2)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>2</WariantFormularza>
+        <DataWytworzeniaFa>2025-01-15T10:00:00Z</DataWytworzeniaFa>
+        <SystemInfo>ksef-client-ts validation test</SystemInfo>
+    </Naglowek>
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>5213003700</NIP>
+            <Nazwa>Firma Testowa sp. z o.o.</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ul. Testowa 1</AdresL1>
+            <AdresL2>00-001 Warszawa</AdresL2>
+        </Adres>
+    </Podmiot1>
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>3861610227</NIP>
+            <Nazwa>Kontrahent Testowy</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ul. Kontrahentowa 2</AdresL1>
+            <AdresL2>00-002 Warszawa</AdresL2>
+        </Adres>
+    </Podmiot2>
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2025-01-15</P_1>
+        <P_1M>Warszawa</P_1M>
+        <P_2>FV/2025/001</P_2>
+        <P_6>2025-01-15</P_6>
+        <P_13_1>500.00</P_13_1>
+        <P_14_1>115.00</P_14_1>
+        <P_15>615.00</P_15>
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie>
+                <P_19N>1</P_19N>
+            </Zwolnienie>
+            <NoweSrodkiTransportu>
+                <P_22N>1</P_22N>
+            </NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy>
+                <P_PMarzyN>1</P_PMarzyN>
+            </PMarzy>
+        </Adnotacje>
+        <RodzajFaktury>VAT</RodzajFaktury>
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <P_7>Usluga testowa</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>5</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>500.00</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+        <Platnosc>
+            <Zaplacono>1</Zaplacono>
+            <DataZaplaty>2025-01-15</DataZaplaty>
+            <FormaPlatnosci>6</FormaPlatnosci>
+        </Platnosc>
+    </Fa>
+</Faktura>

--- a/tests/fixtures/invoices/valid-rr1.xml
+++ b/tests/fixtures/invoices/valid-rr1.xml
@@ -39,11 +39,14 @@
         <FakturaRRWiersz>
             <NrWierszaFa>1</NrWierszaFa>
             <P_5>Ziemniaki</P_5>
-            <P_7>100.00</P_7>
-            <P_8>kg</P_8>
-            <P_9A>5.00</P_9A>
-            <P_10>500.00</P_10>
-            <P_11>7</P_11>
+            <P_6A>Klasa I jadalne</P_6A>
+            <P_6B>100</P_6B>
+            <P_6C>kg</P_6C>
+            <P_7>5.00</P_7>
+            <P_8>500.00</P_8>
+            <P_9>7</P_9>
+            <P_10>35.00</P_10>
+            <P_11>535.00</P_11>
         </FakturaRRWiersz>
     </FakturaRR>
 </FakturaRRStrukt>

--- a/tests/unit/validation/invoice-validation-integration.test.ts
+++ b/tests/unit/validation/invoice-validation-integration.test.ts
@@ -58,6 +58,84 @@ describe('FA(3) invoice validation', () => {
   });
 });
 
+describe('FA(2) invoice validation', () => {
+  const xml = readFixture('valid-fa2.xml');
+
+  it('passes well-formedness check', () => {
+    const result = validateWellFormedness(xml);
+    expect(result.valid).toBe(true);
+    expect(result.schemaType).toBe('FA2');
+  });
+
+  it('auto-detects FA2 schema from namespace', () => {
+    const result = validateWellFormedness(xml);
+    expect(result.schemaType).toBe('FA2');
+  });
+
+  it('passes schema validation', async () => {
+    const result = await validateSchema(xml);
+    expect(result.schemaType).toBe('FA2');
+    if (!result.valid) {
+      console.log('Schema errors:', JSON.stringify(result.errors, null, 2));
+    }
+    expect(result.valid).toBe(true);
+  });
+
+  it('passes business rules (valid NIPs)', () => {
+    const result = validateBusinessRules(xml);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('passes full combined validation', async () => {
+    const result = await validate(xml);
+    if (!result.valid) {
+      console.log('Validation errors:', JSON.stringify(result.errors, null, 2));
+    }
+    expect(result.valid).toBe(true);
+    expect(result.schemaType).toBe('FA2');
+  });
+});
+
+describe('FA_RR(1) invoice validation', () => {
+  const xml = readFixture('valid-rr1.xml');
+
+  it('passes well-formedness check', () => {
+    const result = validateWellFormedness(xml);
+    expect(result.valid).toBe(true);
+    expect(result.schemaType).toBe('RR1_V11E');
+  });
+
+  it('auto-detects RR1_V11E schema from namespace', () => {
+    const result = validateWellFormedness(xml);
+    expect(result.schemaType).toBe('RR1_V11E');
+  });
+
+  it('passes schema validation', async () => {
+    const result = await validateSchema(xml);
+    expect(result.schemaType).toBe('RR1_V11E');
+    if (!result.valid) {
+      console.log('Schema errors:', JSON.stringify(result.errors, null, 2));
+    }
+    expect(result.valid).toBe(true);
+  });
+
+  it('passes business rules (valid NIPs)', () => {
+    const result = validateBusinessRules(xml);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('passes full combined validation', async () => {
+    const result = await validate(xml);
+    if (!result.valid) {
+      console.log('Validation errors:', JSON.stringify(result.errors, null, 2));
+    }
+    expect(result.valid).toBe(true);
+    expect(result.schemaType).toBe('RR1_V11E');
+  });
+});
+
 describe('Invalid invoice fixtures', () => {
   it('Level 1: detects malformed XML', () => {
     const xml = readFixture('invalid-malformed.xml');

--- a/tests/unit/validation/invoice-validation-integration.test.ts
+++ b/tests/unit/validation/invoice-validation-integration.test.ts
@@ -82,6 +82,14 @@ describe('Invalid invoice fixtures', () => {
     expect(result.errors.some(e => e.code === 'INVALID_NIP_CHECKSUM')).toBe(true);
   });
 
+  it('Level 2: rejects unknown element inside FaWiersz (strict mode)', async () => {
+    const xml = readFixture('invalid-unknown-element-in-fawiersz-fa3.xml');
+    const result = await validateSchema(xml);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.code === 'UNRECOGNIZED_KEY')).toBe(true);
+    expect(result.errors.some(e => e.path?.includes('FaWiersz'))).toBe(true);
+  });
+
   it('full pipeline rejects malformed XML early', async () => {
     const xml = readFixture('invalid-malformed.xml');
     const result = await validate(xml);

--- a/tests/unit/validation/validate-batch.test.ts
+++ b/tests/unit/validation/validate-batch.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { validateBatch } from '../../../src/validation/invoice-validator.js';
+
+const fixturesDir = path.join(__dirname, '../../fixtures/invoices');
+const readFixture = (name: string) => fs.readFileSync(path.join(fixturesDir, name), 'utf-8');
+
+describe('validateBatch', () => {
+  it('returns valid for all valid invoices', async () => {
+    const invoices = [
+      { fileName: 'valid-fa3.xml', xml: readFixture('valid-fa3.xml') },
+      { fileName: 'valid-pef3.xml', xml: readFixture('valid-pef3.xml') },
+    ];
+    const result = await validateBatch(invoices);
+    expect(result.valid).toBe(true);
+    expect(result.results).toHaveLength(2);
+    expect(result.results.every(r => r.result.valid)).toBe(true);
+  });
+
+  it('returns invalid when all invoices fail', async () => {
+    const invoices = [
+      { fileName: 'bad-nip.xml', xml: readFixture('invalid-bad-nip-fa3.xml') },
+      { fileName: 'malformed.xml', xml: readFixture('invalid-malformed.xml') },
+    ];
+    const result = await validateBatch(invoices);
+    expect(result.valid).toBe(false);
+    expect(result.results.every(r => !r.result.valid)).toBe(true);
+  });
+
+  it('returns invalid with mixed valid and invalid invoices', async () => {
+    const invoices = [
+      { fileName: 'valid-fa3.xml', xml: readFixture('valid-fa3.xml') },
+      { fileName: 'bad-nip.xml', xml: readFixture('invalid-bad-nip-fa3.xml') },
+      { fileName: 'valid-pef3.xml', xml: readFixture('valid-pef3.xml') },
+    ];
+    const result = await validateBatch(invoices);
+    expect(result.valid).toBe(false);
+    expect(result.results).toHaveLength(3);
+    expect(result.results[0]!.result.valid).toBe(true);
+    expect(result.results[1]!.result.valid).toBe(false);
+    expect(result.results[1]!.fileName).toBe('bad-nip.xml');
+    expect(result.results[2]!.result.valid).toBe(true);
+  });
+
+  it('returns valid for empty input', async () => {
+    const result = await validateBatch([]);
+    expect(result.valid).toBe(true);
+    expect(result.results).toHaveLength(0);
+  });
+
+  it('preserves file names in results', async () => {
+    const invoices = [
+      { fileName: 'invoice-001.xml', xml: readFixture('valid-fa3.xml') },
+      { fileName: 'invoice-002.xml', xml: readFixture('valid-fa3.xml') },
+    ];
+    const result = await validateBatch(invoices);
+    expect(result.results.map(r => r.fileName)).toEqual(['invoice-001.xml', 'invoice-002.xml']);
+  });
+
+  it('detects schema type for each invoice', async () => {
+    const invoices = [
+      { fileName: 'fa3.xml', xml: readFixture('valid-fa3.xml') },
+      { fileName: 'pef3.xml', xml: readFixture('valid-pef3.xml') },
+    ];
+    const result = await validateBatch(invoices);
+    expect(result.results[0]!.result.schemaType).toBe('FA3');
+    expect(result.results[1]!.result.schemaType).toBe('PEF3');
+  });
+});


### PR DESCRIPTION
## Summary
- **Strict invoice validation** — Zod schemas now use `.strict()` to reject unknown XML elements before they reach KSeF (error 450)
- **Batch invoice validation** — `--validate` flag works for directory batch sends in CLI; `validate` option added to programmatic `uploadBatch()` API with per-file error reporting
- **OnlyMetadata export** — `--only-metadata` flag for `invoice export` and `invoice export-incremental` CLI commands
- FA(2) and FA_RR(1) integration validation tests, test fixtures, .gitignore fix

## Test plan
- [x] All 1357 unit tests pass (`yarn test`)
- [x] E2E tests pass (`yarn test:e2e`)
- [x] Manual: `ksef invoice send ./dir/ --validate` catches invalid invoices
- [x] Manual: `ksef invoice send file.zip --stream --validate` shows improved warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)