### PR TITLE
feat: v0.6.1 — session state, file hash verification, holidays, parallel batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [0.6.1] - 2026-04-06
 
 ### Added
+- **File hash verification** — downloaded invoices and export parts are now verified against the SHA-256 hash from the `x-ms-meta-hash` response header. Export workflows verify encrypted part integrity by default (opt out with `verifyHash: false`). `getInvoice()` returns the hash alongside the XML for caller-side verification.
 - **Documentation** — new VitePress page: Polish Holidays reference with full holiday list, calculation details, and usage examples.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.1] - 2026-04-06
+
+### Added
+
+### Fixed
+
 ## [0.6.0] - 2026-04-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 - **Session state serialization** — online sessions can now be serialized to JSON via `handle.getState()` and restored with `resumeOnlineSession(client, state)`. Enables fault-tolerant invoice sending across process restarts without re-opening sessions.
 - **File hash verification** — downloaded invoices and export parts are now verified against the SHA-256 hash from the `x-ms-meta-hash` response header. Export workflows verify encrypted part integrity by default (opt out with `verifyHash: false`). `getInvoice()` returns the hash alongside the XML for caller-side verification.
+- **Parallel batch upload** — configurable `parallelism` option for batch part uploads. Controls how many parts are uploaded concurrently instead of all-at-once (buffer) or one-by-one (stream). Available via `BatchUploadOptions.parallelism` and CLI `--parallelism` flag on `ksef invoice send`.
 - **Documentation** — new VitePress page: Polish Holidays reference with full holiday list, calculation details, and usage examples.
 
 ### Fixed
+- **Batch upload error detection** — presigned URL upload errors (4xx/5xx) in buffer-based batch uploads are now detected and thrown instead of being silently ignored.
 - **Polish holidays in deadline calculation** — `nextBusinessDay()` and `addBusinessDays()` now skip 14 Polish statutory holidays (9 fixed + 4 Easter-based + Wigilia since 2025), not just weekends. Fixes legally incorrect deadlines that could fall on holidays like Christmas or Corpus Christi.
 
 ## [0.6.0] - 2026-04-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ All notable changes to this project will be documented in this file.
 ## [0.6.1] - 2026-04-06
 
 ### Added
+
 - **Session state serialization** — online sessions can be saved to JSON and restored across process restarts for fault-tolerant invoice sending.
 - **File hash verification** — downloaded invoices and export parts are verified against SHA-256 checksums to detect corruption or tampering. Enabled by default for exports (opt out with `verifyHash: false`).
 - **Parallel batch upload** — batch parts can be uploaded concurrently with a configurable concurrency limit (CLI: `--parallelism`).
 - **Documentation** — added a Polish Holidays reference page.
 
 ### Fixed
+
 - **Batch upload error detection** — presigned URL upload errors are now surfaced correctly instead of being silently ignored.
 - **Polish holidays in deadline calculation** — business-day calculations now correctly account for all 14 Polish statutory holidays (since 2025), not just weekends.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [0.6.1] - 2026-04-06
 
 ### Added
+- **Session state serialization** — online sessions can now be serialized to JSON via `handle.getState()` and restored with `resumeOnlineSession(client, state)`. Enables fault-tolerant invoice sending across process restarts without re-opening sessions.
 - **File hash verification** — downloaded invoices and export parts are now verified against the SHA-256 hash from the `x-ms-meta-hash` response header. Export workflows verify encrypted part integrity by default (opt out with `verifyHash: false`). `getInvoice()` returns the hash alongside the XML for caller-side verification.
 - **Documentation** — new VitePress page: Polish Holidays reference with full holiday list, calculation details, and usage examples.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ All notable changes to this project will be documented in this file.
 ## [0.6.1] - 2026-04-06
 
 ### Added
-- **Session state serialization** — online sessions can now be serialized to JSON via `handle.getState()` and restored with `resumeOnlineSession(client, state)`. Enables fault-tolerant invoice sending across process restarts without re-opening sessions.
-- **File hash verification** — downloaded invoices and export parts are now verified against the SHA-256 hash from the `x-ms-meta-hash` response header. Export workflows verify encrypted part integrity by default (opt out with `verifyHash: false`). `getInvoice()` returns the hash alongside the XML for caller-side verification.
-- **Parallel batch upload** — configurable `parallelism` option for batch part uploads. Controls how many parts are uploaded concurrently instead of all-at-once (buffer) or one-by-one (stream). Available via `BatchUploadOptions.parallelism` and CLI `--parallelism` flag on `ksef invoice send`.
-- **Documentation** — new VitePress page: Polish Holidays reference with full holiday list, calculation details, and usage examples.
+- **Session state serialization** — online sessions can be saved to JSON and restored across process restarts for fault-tolerant invoice sending.
+- **File hash verification** — downloaded invoices and export parts are verified against SHA-256 checksums to detect corruption or tampering. Enabled by default for exports (opt out with `verifyHash: false`).
+- **Parallel batch upload** — batch parts can be uploaded concurrently with a configurable concurrency limit (CLI: `--parallelism`).
+- **Documentation** — added a Polish Holidays reference page.
 
 ### Fixed
-- **Batch upload error detection** — presigned URL upload errors (4xx/5xx) in buffer-based batch uploads are now detected and thrown instead of being silently ignored.
-- **Polish holidays in deadline calculation** — `nextBusinessDay()` and `addBusinessDays()` now skip 14 Polish statutory holidays (9 fixed + 4 Easter-based + Wigilia since 2025), not just weekends. Fixes legally incorrect deadlines that could fall on holidays like Christmas or Corpus Christi.
+- **Batch upload error detection** — presigned URL upload errors are now surfaced correctly instead of being silently ignored.
+- **Polish holidays in deadline calculation** — business-day calculations now correctly account for all 14 Polish statutory holidays (since 2025), not just weekends.
 
 ## [0.6.0] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this project will be documented in this file.
 ## [0.6.1] - 2026-04-06
 
 ### Added
+- **Documentation** — new VitePress page: Polish Holidays reference with full holiday list, calculation details, and usage examples.
 
 ### Fixed
+- **Polish holidays in deadline calculation** — `nextBusinessDay()` and `addBusinessDays()` now skip 14 Polish statutory holidays (9 fixed + 4 Easter-based + Wigilia since 2025), not just weekends. Fixes legally incorrect deadlines that could fall on holidays like Christmas or Corpus Christi.
 
 ## [0.6.0] - 2026-04-05
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
           { text: 'Cryptography', link: '/cryptography' },
           { text: 'QR Codes', link: '/qr-codes' },
           { text: 'Offline Mode', link: '/offline-mode' },
+          { text: 'Polish Holidays', link: '/polish-holidays' },
           { text: 'Validation', link: '/validation' },
           { text: 'Error Handling', link: '/error-handling' },
           { text: 'External Signing', link: '/external-signing' },

--- a/docs/offline-mode.md
+++ b/docs/offline-mode.md
@@ -13,7 +13,7 @@ KSeF defines four offline modes per Polish VAT Act (art. 106nda/106nh/106nf):
 | `awaryjny` | KSeF failure (emergency, announced via BIP) | 7 business days from failure end |
 | `awaria_calkowita` | Total system failure (mass media announcement) | Invoice obligation suspended entirely |
 
-Business days exclude Saturdays and Sundays.
+Business days exclude Saturdays, Sundays, and [Polish statutory holidays](./polish-holidays.md).
 
 ## Quick Start (CLI)
 

--- a/docs/polish-holidays.md
+++ b/docs/polish-holidays.md
@@ -1,0 +1,88 @@
+# Polish Statutory Holidays
+
+Business day calculations for [offline invoice deadlines](./offline-mode.md) exclude weekends **and** Polish statutory holidays, as required by Polish law (Ordynacja podatkowa, art. 12 &sect;5).
+
+## Holiday List
+
+Source: [Ustawa z dnia 18 stycznia 1951 r. o dniach wolnych od pracy](https://isap.sejm.gov.pl/isap.nsf/DocDetails.xsp?id=wdu19510040028) (Dz.U. z 2025 r., poz. 296).
+
+### Fixed Holidays (10)
+
+| Date | Name | Notes |
+|------|------|-------|
+| 1 January | Nowy Rok | New Year's Day |
+| 6 January | Trzech Króli | Epiphany |
+| 1 May | Święto Państwowe | Labour Day |
+| 3 May | Święto Narodowe Trzeciego Maja | Constitution Day |
+| 15 August | Wniebowzięcie NMP | Assumption of Mary |
+| 1 November | Wszystkich Świętych | All Saints' Day |
+| 11 November | Narodowe Święto Niepodległości | Independence Day |
+| 24 December | Wigilia Bożego Narodzenia | Christmas Eve (since 2025) |
+| 25 December | Boże Narodzenie (1st day) | Christmas Day |
+| 26 December | Boże Narodzenie (2nd day) | St. Stephen's Day |
+
+> **Note:** Christmas Eve (24 December) was added by the amendment of 6 December 2024 (Dz.U. 2024, poz. 1965), effective from 1 February 2025. For years before 2025, this date is not treated as a holiday.
+
+### Moveable Holidays (4, Easter-based)
+
+| Holiday | Calculation | Example (2026) |
+|---------|-------------|-----------------|
+| Wielkanoc (Easter Sunday) | Computus algorithm | 5 April |
+| Poniedziałek Wielkanocny (Easter Monday) | Easter + 1 day | 6 April |
+| Zielone Świątki (Pentecost) | Easter + 49 days | 24 May |
+| Boże Ciało (Corpus Christi) | Easter + 60 days | 4 June |
+
+> Pentecost always falls on a Sunday, so it does not affect business day calculations. It is included for legal completeness.
+
+### Total Count
+
+- **14 holidays** per year (2025 onwards)
+- **13 holidays** per year (2024 and earlier, before Wigilia amendment)
+
+## Implementation
+
+The holiday logic is in `src/offline/holidays.ts`:
+
+- **`computeEasterSunday(year)`** — computes Easter Sunday using the Anonymous Gregorian algorithm (Meeus/Jones/Butcher). Pure math, no external dependencies.
+- **`getPolishHolidays(year)`** — returns a `Set<string>` of ISO date strings (`YYYY-MM-DD`) for all statutory holidays in the given year. Results are cached per year.
+- **`isPolishHoliday(date)`** — checks if a UTC `Date` falls on a Polish statutory holiday.
+
+These functions are used internally by `nextBusinessDay()` and `addBusinessDays()` in `src/offline/deadline.ts`. The integration is transparent — all deadline functions (`calculateOfflineDeadline`, `extendDeadlineForMaintenance`) automatically skip holidays without any API changes.
+
+### Usage
+
+```typescript
+import {
+  computeEasterSunday,
+  getPolishHolidays,
+  isPolishHoliday,
+  nextBusinessDay,
+} from 'ksef-client-ts';
+
+// Easter Sunday for 2026
+computeEasterSunday(2026); // → 2026-04-05
+
+// All 14 holidays for 2026
+const holidays = getPolishHolidays(2026);
+// Set { '2026-01-01', '2026-01-06', '2026-04-05', ... }
+
+// Check a specific date
+isPolishHoliday(new Date('2026-12-25')); // → true (Christmas)
+isPolishHoliday(new Date('2026-12-27')); // → false
+
+// nextBusinessDay skips holidays automatically
+nextBusinessDay(new Date('2026-12-23')); // Wed → Mon Dec 28
+// (skips: Thu Dec 24 Wigilia, Fri Dec 25 Christmas, Sat-Sun weekend)
+```
+
+## Holiday Clusters
+
+Some holiday combinations create extended non-working periods. Examples for 2026:
+
+| Period | Non-working days | Next business day |
+|--------|-----------------|-------------------|
+| Christmas 2026 | Dec 24 (Thu, Wigilia) + Dec 25 (Fri) + Dec 26-27 (Sat-Sun) | Mon Dec 28 |
+| Easter 2026 | Apr 5 (Sun, Easter) + Apr 6 (Mon, Easter Monday) | Tue Apr 7 |
+| May holidays 2026 | May 1 (Fri) + May 2 (Sat) + May 3 (Sun, Constitution Day) | Mon May 4 |
+
+These clusters are handled automatically — `nextBusinessDay()` and `addBusinessDays()` keep advancing until a working day is found.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ksef-client-ts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "TypeScript client for the Polish National e-Invoice System (KSeF) API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/cli/commands/invoice.ts
+++ b/src/cli/commands/invoice.ts
@@ -85,6 +85,7 @@ const send = defineCommand({
     stream: { type: 'boolean', description: 'Use stream-based batch upload (for ZIP files, reduces memory usage)' },
     formCode: { type: 'string', description: 'Document type: FA2, FA3, PEF3, PEFKOR3, FARR1 (default: FA3)' },
     validate: { type: 'boolean', description: 'Validate XML before sending' },
+    parallelism: { type: 'string', description: 'Number of concurrent part uploads (batch mode)' },
     env: { type: 'string', description: 'Environment (test/demo/prod)' },
     json: { type: 'boolean', description: 'Output as JSON' },
     verbose: { type: 'boolean', description: 'Show HTTP request/response details' },
@@ -98,6 +99,11 @@ const send = defineCommand({
       const config = loadConfig();
       const nip = args.nip ?? config.nip;
       const filePath = args.path;
+
+      const parallelism = args.parallelism ? parseInt(args.parallelism as string, 10) : undefined;
+      if (parallelism !== undefined && (isNaN(parallelism) || parallelism < 1)) {
+        throw new Error('--parallelism must be a positive integer');
+      }
 
       const formCodeKey = args.formCode as string | undefined;
       let formCode: FormCode = DEFAULT_FORM_CODE;
@@ -143,6 +149,7 @@ const send = defineCommand({
         const result = await uploadBatchStream(client, zipStreamFactory, zipSize, {
           formCode,
           pollOptions: { intervalMs: 3000 },
+          parallelism,
         });
 
         if (args.json) {
@@ -222,7 +229,7 @@ const send = defineCommand({
         );
 
         saveOnlineSessionRef(openResult.referenceNumber);
-        await client.batchSession.sendParts(openResult, parts);
+        await client.batchSession.sendParts(openResult, parts, parallelism);
         await client.batchSession.closeSession(openResult.referenceNumber);
         clearOnlineSessionRef();
 

--- a/src/cli/commands/invoice.ts
+++ b/src/cli/commands/invoice.ts
@@ -100,8 +100,8 @@ const send = defineCommand({
       const nip = args.nip ?? config.nip;
       const filePath = args.path;
 
-      const parallelism = args.parallelism ? parseInt(args.parallelism as string, 10) : undefined;
-      if (parallelism !== undefined && (isNaN(parallelism) || parallelism < 1)) {
+      const parallelism = args.parallelism ? Number(args.parallelism) : undefined;
+      if (parallelism !== undefined && (!Number.isInteger(parallelism) || parallelism < 1)) {
         throw new Error('--parallelism must be a positive integer');
       }
 

--- a/src/cli/commands/invoice.ts
+++ b/src/cli/commands/invoice.ts
@@ -299,10 +299,10 @@ const get = defineCommand({
       const globalOpts = getGlobalOpts(args);
       const { client } = await requireSession(globalOpts);
 
-      const xml = await client.invoices.getInvoice(args.ksefNumber);
+      const { xml, hash } = await client.invoices.getInvoice(args.ksefNumber);
 
       if (args.json) {
-        outputResult({ ksefNumber: args.ksefNumber, xml }, { json: true });
+        outputResult({ ksefNumber: args.ksefNumber, xml, hash }, { json: true });
         return;
       }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -41,6 +41,7 @@ export class KSeFClient {
   readonly qr: VerificationLinkService;
   readonly options: ResolvedOptions;
   readonly authManager: AuthManager;
+  private readonly _baseRestClientConfig: Omit<RestClientConfig, 'authManager'>;
   private _offline?: OfflineInvoiceWorkflow;
 
   constructor(options?: KSeFClientOptions) {
@@ -55,6 +56,8 @@ export class KSeFClient {
     this.authManager = authManager;
 
     const restClientConfig = buildRestClientConfig(options, authManager);
+    const { authManager: _am, ...baseConfig } = restClientConfig;
+    this._baseRestClientConfig = baseConfig;
     const restClient = new RestClient(this.options, restClientConfig);
 
     const fetcher = new CertificateFetcher(restClient);
@@ -80,6 +83,11 @@ export class KSeFClient {
       this._offline = new OfflineInvoiceWorkflow(this.qr);
     }
     return this._offline;
+  }
+
+  /** @internal Create a RestClient with a different AuthManager, preserving transport/retry/rateLimit config. */
+  createScopedRestClient(authManager: AuthManager): RestClient {
+    return new RestClient(this.options, { ...this._baseRestClientConfig, authManager });
   }
 
   async loginWithToken(token: string, nip: string): Promise<void> {

--- a/src/models/invoices/types.ts
+++ b/src/models/invoices/types.ts
@@ -144,6 +144,16 @@ export interface QueryInvoicesMetadataResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Invoice download result
+// ---------------------------------------------------------------------------
+
+export interface InvoiceResult {
+  xml: string;
+  /** SHA-256 base64 hash from the `x-ms-meta-hash` response header, if present. */
+  hash?: string;
+}
+
+// ---------------------------------------------------------------------------
 // Export
 // ---------------------------------------------------------------------------
 

--- a/src/models/sessions/index.ts
+++ b/src/models/sessions/index.ts
@@ -1,3 +1,4 @@
 export * from './online-types.js';
 export * from './batch-types.js';
 export * from './status-types.js';
+export * from './session-state.js';

--- a/src/models/sessions/session-state.ts
+++ b/src/models/sessions/session-state.ts
@@ -1,7 +1,12 @@
 import type { FormCode } from '../common.js';
 import type { PartUploadRequest } from './batch-types.js';
 
-/** Serializable state of an online session. All binary data is Base64-encoded. */
+/**
+ * Serializable state of an online session. All binary data is Base64-encoded.
+ *
+ * **Security:** contains AES encryption keys in plaintext. Treat serialized
+ * state as sensitive data — encrypt at rest or store in a secure vault.
+ */
 export interface OnlineSessionState {
   referenceNumber: string;
   /** AES-256 cipher key, Base64-encoded. */

--- a/src/models/sessions/session-state.ts
+++ b/src/models/sessions/session-state.ts
@@ -17,6 +17,8 @@ export interface OnlineSessionState {
   formCode: FormCode;
   /** Session expiration time, ISO 8601. */
   validUntil: string;
+  /** Whether invoices are validated against XSD before sending. */
+  validate?: boolean;
 }
 
 /** Serializable state of a batch session. */

--- a/src/models/sessions/session-state.ts
+++ b/src/models/sessions/session-state.ts
@@ -1,0 +1,27 @@
+import type { FormCode } from '../common.js';
+import type { PartUploadRequest } from './batch-types.js';
+
+/** Serializable state of an online session. All binary data is Base64-encoded. */
+export interface OnlineSessionState {
+  referenceNumber: string;
+  /** AES-256 cipher key, Base64-encoded. */
+  aesKey: string;
+  /** AES-256 initialization vector, Base64-encoded. */
+  iv: string;
+  accessToken: string;
+  formCode: FormCode;
+  /** Session expiration time, ISO 8601. */
+  validUntil: string;
+}
+
+/** Serializable state of a batch session. */
+export interface BatchSessionState {
+  referenceNumber: string;
+  /** AES-256 cipher key, Base64-encoded. */
+  aesKey: string;
+  /** AES-256 initialization vector, Base64-encoded. */
+  iv: string;
+  accessToken: string;
+  formCode: FormCode;
+  partUploadRequests: PartUploadRequest[];
+}

--- a/src/offline/deadline.ts
+++ b/src/offline/deadline.ts
@@ -9,6 +9,7 @@
  */
 
 import type { MaintenanceWindow, OfflineMode, OfflineReason } from './types.js';
+import { isPolishHoliday } from './holidays.js';
 
 const FAR_FUTURE = new Date('9999-12-31T23:59:59Z');
 
@@ -24,7 +25,7 @@ export function getDefaultReason(mode: OfflineMode): OfflineReason {
 export function nextBusinessDay(from: Date): Date {
   const d = new Date(from);
   d.setUTCDate(d.getUTCDate() + 1);
-  while (d.getUTCDay() === 0 || d.getUTCDay() === 6) {
+  while (d.getUTCDay() === 0 || d.getUTCDay() === 6 || isPolishHoliday(d)) {
     d.setUTCDate(d.getUTCDate() + 1);
   }
   return d;
@@ -38,7 +39,7 @@ export function addBusinessDays(from: Date, days: number): Date {
   let remaining = days;
   while (remaining > 0) {
     d.setUTCDate(d.getUTCDate() + 1);
-    if (d.getUTCDay() !== 0 && d.getUTCDay() !== 6) {
+    if (d.getUTCDay() !== 0 && d.getUTCDay() !== 6 && !isPolishHoliday(d)) {
       remaining--;
     }
   }

--- a/src/offline/holidays.ts
+++ b/src/offline/holidays.ts
@@ -1,0 +1,114 @@
+/**
+ * Polish statutory public holidays.
+ *
+ * Polish law (Ordynacja podatkowa, art. 12 §5) excludes both weekends
+ * and statutory holidays from business day counts. This module provides
+ * the full list of 13 Polish holidays per year, including moveable
+ * holidays derived from the Easter date.
+ */
+
+const holidayCache = new Map<number, Set<string>>();
+
+/** Format a UTC date as 'YYYY-MM-DD'. */
+function toDateKey(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/** Create a UTC date and return its key. */
+function dateKey(year: number, month: number, day: number): string {
+  return toDateKey(new Date(Date.UTC(year, month - 1, day)));
+}
+
+/** Add calendar days to a UTC date. */
+function addDays(d: Date, n: number): Date {
+  const result = new Date(d);
+  result.setUTCDate(result.getUTCDate() + n);
+  return result;
+}
+
+/**
+ * Compute Easter Sunday for a given year using the
+ * Anonymous Gregorian algorithm (Meeus/Jones/Butcher).
+ * Returns a UTC Date.
+ */
+export function computeEasterSunday(year: number): Date {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31);
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+/**
+ * Get all Polish statutory holidays for a given year.
+ * Returns a Set of ISO date strings ('YYYY-MM-DD').
+ *
+ * Source: Ustawa z dnia 18 stycznia 1951 r. o dniach wolnych od pracy
+ * (Dz.U. z 2025 r., poz. 296)
+ *
+ * Fixed holidays:
+ *   Jan 1  — Nowy Rok
+ *   Jan 6  — Święto Trzech Króli (Epiphany)
+ *   May 1  — Święto Państwowe
+ *   May 3  — Święto Narodowe Trzeciego Maja
+ *   Aug 15 — Wniebowzięcie NMP
+ *   Nov 1  — Wszystkich Świętych
+ *   Nov 11 — Narodowe Święto Niepodległości
+ *   Dec 24 — Wigilia Bożego Narodzenia (since 2025, Dz.U. 2024 poz. 1965)
+ *   Dec 25 — Boże Narodzenie (1st day)
+ *   Dec 26 — Boże Narodzenie (2nd day)
+ *
+ * Moveable holidays (Easter-based):
+ *   Easter Sunday    — Wielkanoc
+ *   Easter Monday    — Poniedziałek Wielkanocny (Easter + 1)
+ *   Pentecost Sunday — Zielone Świątki (Easter + 49, always Sunday)
+ *   Corpus Christi   — Boże Ciało (Easter + 60)
+ *
+ * Count: 14 (year >= 2025), 13 (year <= 2024)
+ */
+export function getPolishHolidays(year: number): Set<string> {
+  const cached = holidayCache.get(year);
+  if (cached) return cached;
+
+  const easter = computeEasterSunday(year);
+
+  const holidays = new Set<string>([
+    // Fixed
+    dateKey(year, 1, 1),
+    dateKey(year, 1, 6),
+    dateKey(year, 5, 1),
+    dateKey(year, 5, 3),
+    dateKey(year, 8, 15),
+    dateKey(year, 11, 1),
+    dateKey(year, 11, 11),
+    dateKey(year, 12, 25),
+    dateKey(year, 12, 26),
+    // Wigilia — added by Dz.U. 2024 poz. 1965, effective from 2025
+    ...(year >= 2025 ? [dateKey(year, 12, 24)] : []),
+    // Moveable
+    toDateKey(easter),
+    toDateKey(addDays(easter, 1)),
+    toDateKey(addDays(easter, 49)),
+    toDateKey(addDays(easter, 60)),
+  ]);
+
+  holidayCache.set(year, holidays);
+  return holidays;
+}
+
+/**
+ * Check if a UTC date falls on a Polish statutory holiday.
+ */
+export function isPolishHoliday(date: Date): boolean {
+  return getPolishHolidays(date.getUTCFullYear()).has(toDateKey(date));
+}

--- a/src/offline/holidays.ts
+++ b/src/offline/holidays.ts
@@ -76,7 +76,7 @@ export function computeEasterSunday(year: number): Date {
  *
  * Count: 14 (year >= 2025), 13 (year <= 2024)
  */
-export function getPolishHolidays(year: number): Set<string> {
+export function getPolishHolidays(year: number): ReadonlySet<string> {
   const cached = holidayCache.get(year);
   if (cached) return cached;
 

--- a/src/offline/holidays.ts
+++ b/src/offline/holidays.ts
@@ -3,8 +3,8 @@
  *
  * Polish law (Ordynacja podatkowa, art. 12 §5) excludes both weekends
  * and statutory holidays from business day counts. This module provides
- * the full list of 13 Polish holidays per year, including moveable
- * holidays derived from the Easter date.
+ * the full list of Polish statutory holidays per year (14 since 2025,
+ * 13 before), including moveable holidays derived from the Easter date.
  */
 
 const holidayCache = new Map<number, Set<string>>();

--- a/src/offline/index.ts
+++ b/src/offline/index.ts
@@ -21,7 +21,7 @@ export {
   getTimeUntilDeadline,
 } from './deadline.js';
 
-export { computeEasterSunday, getPolishHolidays, isPolishHoliday } from './holidays.js';
+export { getPolishHolidays, isPolishHoliday } from './holidays.js';
 
 export type { OfflineInvoiceFilter, OfflineInvoiceStorage, OfflineInvoiceUpdates } from './storage.js';
 export { InMemoryOfflineInvoiceStorage } from './storage.js';

--- a/src/offline/index.ts
+++ b/src/offline/index.ts
@@ -21,6 +21,8 @@ export {
   getTimeUntilDeadline,
 } from './deadline.js';
 
+export { computeEasterSunday, getPolishHolidays, isPolishHoliday } from './holidays.js';
+
 export type { OfflineInvoiceFilter, OfflineInvoiceStorage, OfflineInvoiceUpdates } from './storage.js';
 export { InMemoryOfflineInvoiceStorage } from './storage.js';
 export { FileOfflineInvoiceStorage } from './file-storage.js';

--- a/src/services/batch-session.ts
+++ b/src/services/batch-session.ts
@@ -31,11 +31,9 @@ export class BatchSessionService {
     parts: BatchPartSendingInfo[],
     parallelism?: number,
   ): Promise<void> {
-    const uploadRequests = openResponse.partUploadRequests;
+    const uploadMap = new Map(openResponse.partUploadRequests.map(r => [r.ordinalNumber, r] as const));
     const tasks = parts.map((part) => async () => {
-      const uploadReq = uploadRequests.find(
-        (r) => r.ordinalNumber === part.ordinalNumber,
-      );
+      const uploadReq = uploadMap.get(part.ordinalNumber);
       if (!uploadReq) {
         throw new Error(`No upload request found for part ${part.ordinalNumber}`);
       }
@@ -72,11 +70,9 @@ export class BatchSessionService {
     parts: BatchPartStreamSendingInfo[],
     parallelism?: number,
   ): Promise<void> {
-    const uploadRequests = openResponse.partUploadRequests;
+    const uploadMap = new Map(openResponse.partUploadRequests.map(r => [r.ordinalNumber, r] as const));
     const uploadPart = async (part: BatchPartStreamSendingInfo) => {
-      const uploadReq = uploadRequests.find(
-        (r) => r.ordinalNumber === part.ordinalNumber,
-      );
+      const uploadReq = uploadMap.get(part.ordinalNumber);
       if (!uploadReq) {
         throw new Error(`No upload request found for part ${part.ordinalNumber}`);
       }

--- a/src/services/batch-session.ts
+++ b/src/services/batch-session.ts
@@ -49,7 +49,10 @@ export class BatchSessionService {
         body: part.data,
       });
       if (!resp.ok) {
-        throw new Error(`Upload failed for part ${part.ordinalNumber}: HTTP ${resp.status}`);
+        const body = await resp.text().catch(() => '');
+        throw new Error(
+          `Upload failed for part ${part.ordinalNumber}: HTTP ${resp.status}${body ? ` — ${body}` : ''}`,
+        );
       }
     });
     if (parallelism !== undefined) {
@@ -89,7 +92,10 @@ export class BatchSessionService {
         duplex: 'half',
       });
       if (!resp.ok) {
-        throw new Error(`Upload failed for part ${part.ordinalNumber}: HTTP ${resp.status}`);
+        const body = await resp.text().catch(() => '');
+        throw new Error(
+          `Upload failed for part ${part.ordinalNumber}: HTTP ${resp.status}${body ? ` — ${body}` : ''}`,
+        );
       }
     };
 

--- a/src/services/batch-session.ts
+++ b/src/services/batch-session.ts
@@ -58,7 +58,7 @@ export class BatchSessionService {
       await runWithConcurrency(tasks, parallelism);
     } else {
       const ac = new AbortController();
-      await Promise.all(tasks.map(t => t(ac.signal)));
+      await Promise.all(tasks.map(t => t(ac.signal).catch(err => { ac.abort(); throw err; })));
     }
   }
 
@@ -101,9 +101,9 @@ export class BatchSessionService {
     if (parallelism !== undefined) {
       await runWithConcurrency(parts.map((p) => (signal: AbortSignal) => uploadPart(p, signal)), parallelism);
     } else {
-      const ac = new AbortController();
+      const { signal } = new AbortController();
       for (const part of parts) {
-        await uploadPart(part, ac.signal);
+        await uploadPart(part, signal);
       }
     }
   }

--- a/src/services/batch-session.ts
+++ b/src/services/batch-session.ts
@@ -2,6 +2,7 @@ import { RestClient } from '../http/rest-client.js';
 import { KSEF_FEATURE_HEADER } from '../http/ksef-feature.js';
 import { RestRequest } from '../http/rest-request.js';
 import { Routes } from '../http/routes.js';
+import { runWithConcurrency } from '../utils/concurrency.js';
 import type { UpoVersion } from '../http/ksef-feature.js';
 import type { OpenBatchSessionRequest, OpenBatchSessionResponse, BatchPartSendingInfo, BatchPartStreamSendingInfo } from '../models/sessions/batch-types.js';
 
@@ -28,9 +29,10 @@ export class BatchSessionService {
   async sendParts(
     openResponse: OpenBatchSessionResponse,
     parts: BatchPartSendingInfo[],
+    parallelism?: number,
   ): Promise<void> {
     const uploadRequests = openResponse.partUploadRequests;
-    const tasks = parts.map(async (part) => {
+    const tasks = parts.map((part) => async () => {
       const uploadReq = uploadRequests.find(
         (r) => r.ordinalNumber === part.ordinalNumber,
       );
@@ -41,26 +43,34 @@ export class BatchSessionService {
       for (const [k, v] of Object.entries(uploadReq.headers)) {
         if (v != null) headers[k] = v;
       }
-      await fetch(uploadReq.url, {
+      const resp = await fetch(uploadReq.url, {
         method: uploadReq.method,
         headers,
         body: part.data,
       });
+      if (!resp.ok) {
+        throw new Error(`Upload failed for part ${part.ordinalNumber}: HTTP ${resp.status}`);
+      }
     });
-    await Promise.all(tasks);
+    if (parallelism !== undefined) {
+      await runWithConcurrency(tasks, parallelism);
+    } else {
+      await Promise.all(tasks.map(t => t()));
+    }
   }
 
   /**
-   * Upload parts sequentially (not in parallel) because each part uses a
-   * streaming body (`duplex: 'half'`). Parallel streaming uploads can cause
-   * backpressure issues and exceed memory limits for large payloads.
+   * Upload parts using streaming bodies (`duplex: 'half'`).
+   * By default uploads sequentially to avoid backpressure issues.
+   * Pass `parallelism` to enable bounded concurrent uploads.
    */
   async sendPartsWithStream(
     openResponse: OpenBatchSessionResponse,
     parts: BatchPartStreamSendingInfo[],
+    parallelism?: number,
   ): Promise<void> {
     const uploadRequests = openResponse.partUploadRequests;
-    for (const part of parts) {
+    const uploadPart = async (part: BatchPartStreamSendingInfo) => {
       const uploadReq = uploadRequests.find(
         (r) => r.ordinalNumber === part.ordinalNumber,
       );
@@ -80,6 +90,14 @@ export class BatchSessionService {
       });
       if (!resp.ok) {
         throw new Error(`Upload failed for part ${part.ordinalNumber}: HTTP ${resp.status}`);
+      }
+    };
+
+    if (parallelism !== undefined) {
+      await runWithConcurrency(parts.map((p) => () => uploadPart(p)), parallelism);
+    } else {
+      for (const part of parts) {
+        await uploadPart(part);
       }
     }
   }

--- a/src/services/batch-session.ts
+++ b/src/services/batch-session.ts
@@ -32,7 +32,7 @@ export class BatchSessionService {
     parallelism?: number,
   ): Promise<void> {
     const uploadMap = new Map(openResponse.partUploadRequests.map(r => [r.ordinalNumber, r] as const));
-    const tasks = parts.map((part) => async () => {
+    const tasks = parts.map((part) => async (signal: AbortSignal) => {
       const uploadReq = uploadMap.get(part.ordinalNumber);
       if (!uploadReq) {
         throw new Error(`No upload request found for part ${part.ordinalNumber}`);
@@ -45,6 +45,7 @@ export class BatchSessionService {
         method: uploadReq.method,
         headers,
         body: part.data,
+        signal,
       });
       if (!resp.ok) {
         const body = await resp.text().catch(() => '');
@@ -56,7 +57,8 @@ export class BatchSessionService {
     if (parallelism !== undefined) {
       await runWithConcurrency(tasks, parallelism);
     } else {
-      await Promise.all(tasks.map(t => t()));
+      const ac = new AbortController();
+      await Promise.all(tasks.map(t => t(ac.signal)));
     }
   }
 
@@ -71,7 +73,7 @@ export class BatchSessionService {
     parallelism?: number,
   ): Promise<void> {
     const uploadMap = new Map(openResponse.partUploadRequests.map(r => [r.ordinalNumber, r] as const));
-    const uploadPart = async (part: BatchPartStreamSendingInfo) => {
+    const uploadPart = async (part: BatchPartStreamSendingInfo, signal: AbortSignal) => {
       const uploadReq = uploadMap.get(part.ordinalNumber);
       if (!uploadReq) {
         throw new Error(`No upload request found for part ${part.ordinalNumber}`);
@@ -84,6 +86,7 @@ export class BatchSessionService {
         method: uploadReq.method,
         headers,
         body: part.dataStream,
+        signal,
         // @ts-expect-error -- Node 18+ undici supports duplex for streaming body
         duplex: 'half',
       });
@@ -96,10 +99,11 @@ export class BatchSessionService {
     };
 
     if (parallelism !== undefined) {
-      await runWithConcurrency(parts.map((p) => () => uploadPart(p)), parallelism);
+      await runWithConcurrency(parts.map((p) => (signal: AbortSignal) => uploadPart(p, signal)), parallelism);
     } else {
+      const ac = new AbortController();
       for (const part of parts) {
-        await uploadPart(part);
+        await uploadPart(part, ac.signal);
       }
     }
   }

--- a/src/services/invoice-download.ts
+++ b/src/services/invoice-download.ts
@@ -2,7 +2,7 @@ import { RestClient } from '../http/rest-client.js';
 import { RestRequest } from '../http/rest-request.js';
 import { Routes } from '../http/routes.js';
 import type { OperationResponse, SortOrder } from '../models/common.js';
-import type { InvoiceQueryFilters, QueryInvoicesMetadataResponse, InvoiceExportRequest, InvoiceExportStatusResponse } from '../models/invoices/types.js';
+import type { InvoiceQueryFilters, QueryInvoicesMetadataResponse, InvoiceExportRequest, InvoiceExportStatusResponse, InvoiceResult } from '../models/invoices/types.js';
 
 export class InvoiceDownloadService {
   private readonly restClient: RestClient;
@@ -11,10 +11,13 @@ export class InvoiceDownloadService {
     this.restClient = restClient;
   }
 
-  async getInvoice(ksefNumber: string): Promise<string> {
+  async getInvoice(ksefNumber: string): Promise<InvoiceResult> {
     const req = RestRequest.get(Routes.Invoices.byKsefNumber(ksefNumber));
     const response = await this.restClient.executeRaw(req);
-    return new TextDecoder().decode(response.body);
+    return {
+      xml: new TextDecoder().decode(response.body),
+      hash: response.headers.get('x-ms-meta-hash') ?? undefined,
+    };
   }
 
   async queryInvoiceMetadata(

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -14,11 +14,17 @@ export async function runWithConcurrency(
   if (tasks.length === 0) return;
   const limit = Math.max(1, Math.min(parallelism, tasks.length));
   let index = 0;
+  let aborted = false;
   const workers = Array.from({ length: limit }, async () => {
-    while (index < tasks.length) {
+    while (index < tasks.length && !aborted) {
       const current = index;
       index += 1;
-      await tasks[current]!();
+      try {
+        await tasks[current]!();
+      } catch (err) {
+        aborted = true;
+        throw err;
+      }
     }
   });
   await Promise.all(workers);

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -4,25 +4,29 @@
  * Creates `parallelism` workers that pull from a shared task queue.
  * Safe in single-threaded JS — index read+increment is atomic between await points.
  *
- * @param tasks - Array of async thunks to execute
+ * On first failure the shared AbortController is triggered so that:
+ * 1. No new tasks are dequeued.
+ * 2. In-flight tasks receive the abort signal (e.g. to cancel fetch requests).
+ *
+ * @param tasks - Array of async thunks that receive an AbortSignal
  * @param parallelism - Maximum number of concurrent workers (clamped to [1, tasks.length])
  */
 export async function runWithConcurrency(
-  tasks: Array<() => Promise<void>>,
+  tasks: Array<(signal: AbortSignal) => Promise<void>>,
   parallelism: number,
 ): Promise<void> {
   if (tasks.length === 0) return;
   const limit = Math.max(1, Math.min(parallelism, tasks.length));
+  const controller = new AbortController();
   let index = 0;
-  let aborted = false;
   const workers = Array.from({ length: limit }, async () => {
-    while (index < tasks.length && !aborted) {
+    while (index < tasks.length && !controller.signal.aborted) {
       const current = index;
       index += 1;
       try {
-        await tasks[current]!();
+        await tasks[current]!(controller.signal);
       } catch (err) {
-        aborted = true;
+        controller.abort();
         throw err;
       }
     }

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,25 @@
+/**
+ * Execute async tasks with bounded concurrency using a worker-pool pattern.
+ *
+ * Creates `parallelism` workers that pull from a shared task queue.
+ * Safe in single-threaded JS — index read+increment is atomic between await points.
+ *
+ * @param tasks - Array of async thunks to execute
+ * @param parallelism - Maximum number of concurrent workers (clamped to [1, tasks.length])
+ */
+export async function runWithConcurrency(
+  tasks: Array<() => Promise<void>>,
+  parallelism: number,
+): Promise<void> {
+  if (tasks.length === 0) return;
+  const limit = Math.max(1, Math.min(parallelism, tasks.length));
+  let index = 0;
+  const workers = Array.from({ length: limit }, async () => {
+    while (index < tasks.length) {
+      const current = index;
+      index += 1;
+      await tasks[current]!();
+    }
+  });
+  await Promise.all(workers);
+}

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,11 @@
+import crypto from 'node:crypto';
+
+/** Compute SHA-256 hash of data, returned as base64 string. */
+export function sha256Base64(data: Uint8Array): string {
+  return crypto.createHash('sha256').update(data).digest('base64');
+}
+
+/** Returns true if SHA-256 base64 of `data` matches `expectedHash`. */
+export function verifyHash(data: Uint8Array, expectedHash: string): boolean {
+  return sha256Base64(data) === expectedHash;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,3 +3,4 @@ export type { ZipEntryInput, UnzipOptions } from './zip.js';
 export { decodeJwtPayload, parseKSeFTokenContext } from './jwt.js';
 export type { KSeFTokenContext } from './jwt.js';
 export { sha256Base64, verifyHash } from './hash.js';
+export { runWithConcurrency } from './concurrency.js';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export { createZip, unzip } from './zip.js';
 export type { ZipEntryInput, UnzipOptions } from './zip.js';
 export { decodeJwtPayload, parseKSeFTokenContext } from './jwt.js';
 export type { KSeFTokenContext } from './jwt.js';
+export { sha256Base64, verifyHash } from './hash.js';

--- a/src/validation/patterns.ts
+++ b/src/validation/patterns.ts
@@ -52,7 +52,11 @@ export function isValidNip(value: string): boolean {
   return checksum !== 10 && checksum === Number(value[9]);
 }
 export function isValidVatUe(value: string): boolean { return VatUe.test(value); }
-export function isValidNipVatUe(value: string): boolean { return NipVatUe.test(value); }
+export function isValidNipVatUe(value: string): boolean {
+  if (!NipVatUe.test(value)) return false;
+  const nip = value.split('-')[0]!;
+  return isValidNip(nip);
+}
 export function isValidInternalId(value: string): boolean { return InternalId.test(value); }
 export function isValidPeppolId(value: string): boolean { return PeppolId.test(value); }
 export function isValidReferenceNumber(value: string): boolean { return ReferenceNumber.test(value); }

--- a/src/workflows/batch-session-workflow.ts
+++ b/src/workflows/batch-session-workflow.ts
@@ -27,6 +27,9 @@ export async function uploadBatch(
   zipData: Uint8Array,
   options?: BatchUploadOptions,
 ): Promise<BatchUploadResult> {
+  if (options?.parallelism !== undefined && (!Number.isInteger(options.parallelism) || options.parallelism < 1)) {
+    throw new Error('parallelism must be a positive integer');
+  }
   await client.crypto.init();
 
   if (options?.validate) {
@@ -111,6 +114,9 @@ export async function uploadBatchStream(
   zipSize: number,
   options?: BatchUploadOptions,
 ): Promise<BatchUploadResult> {
+  if (options?.parallelism !== undefined && (!Number.isInteger(options.parallelism) || options.parallelism < 1)) {
+    throw new Error('parallelism must be a positive integer');
+  }
   await client.crypto.init();
   const encData = client.crypto.getEncryptionData();
   const formCode = options?.formCode ?? DEFAULT_FORM_CODE;

--- a/src/workflows/batch-session-workflow.ts
+++ b/src/workflows/batch-session-workflow.ts
@@ -18,6 +18,8 @@ export interface BatchUploadOptions {
   offlineMode?: boolean;
   /** Validate each invoice XML in the ZIP before uploading. */
   validate?: boolean;
+  /** Number of concurrent part uploads. Omit for default behavior (buffer: all parallel, stream: sequential). */
+  parallelism?: number;
 }
 
 export async function uploadBatch(
@@ -77,7 +79,7 @@ export async function uploadBatch(
     },
     ordinalNumber: i + 1,
   }));
-  await client.batchSession.sendParts(openResp, sendingParts);
+  await client.batchSession.sendParts(openResp, sendingParts, options?.parallelism);
 
   await client.batchSession.closeSession(openResp.referenceNumber);
 
@@ -137,7 +139,7 @@ export async function uploadBatchStream(
     options?.upoVersion,
   );
 
-  await client.batchSession.sendPartsWithStream(openResp, streamParts);
+  await client.batchSession.sendPartsWithStream(openResp, streamParts, options?.parallelism);
 
   await client.batchSession.closeSession(openResp.referenceNumber);
 

--- a/src/workflows/incremental-export-workflow.ts
+++ b/src/workflows/incremental-export-workflow.ts
@@ -5,6 +5,7 @@ import type { ContinuationPoints } from './hwm-coordinator.js';
 import type { HwmStore } from './hwm-storage.js';
 import { doExport } from './invoice-export-workflow.js';
 import { updateContinuationPoint, getEffectiveStartDate } from './hwm-coordinator.js';
+import { verifyHash } from '../utils/hash.js';
 
 export interface IncrementalExportOptions {
   subjectType: InvoiceSubjectType;
@@ -16,6 +17,8 @@ export interface IncrementalExportOptions {
   pollOptions?: PollOptions;
   onlyMetadata?: boolean;
   transport?: typeof fetch;
+  /** Verify SHA-256 hash of encrypted parts after download. Defaults to true. */
+  verifyHash?: boolean;
   store?: HwmStore;
   onIterationComplete?: (iteration: number, result: ExportResult) => void;
 }
@@ -76,6 +79,9 @@ export async function incrementalExportAndDownload(
         throw new Error(`Download failed for part ${part.ordinalNumber}: HTTP ${resp.status}`);
       }
       const encryptedData = new Uint8Array(await resp.arrayBuffer());
+      if (options.verifyHash !== false && !verifyHash(encryptedData, part.encryptedPartHash)) {
+        throw new Error(`Hash mismatch for export part ${part.ordinalNumber}`);
+      }
       const decrypted = client.crypto.decryptAES256(encryptedData, encData.cipherKey, encData.cipherIv);
       decryptedParts.push(decrypted);
     }

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -1,6 +1,6 @@
 export type { PollOptions, OnlineSessionHandle, UpoInfo, ParsedUpoInfo, BatchUploadResult, ParsedBatchUploadResult, ExportResult, ExportDownloadResult, ExportExtractedResult } from './types.js';
 export { pollUntil } from './polling.js';
-export { openOnlineSession, openSendAndClose } from './online-session-workflow.js';
+export { openOnlineSession, resumeOnlineSession, openSendAndClose } from './online-session-workflow.js';
 export type { OpenOnlineSessionOptions, SendAndCloseOptions } from './online-session-workflow.js';
 export { uploadBatch, uploadBatchParsed, uploadBatchStream, uploadBatchStreamParsed } from './batch-session-workflow.js';
 export type { BatchUploadOptions, BatchStreamBuildResult } from './batch-session-workflow.js';

--- a/src/workflows/invoice-export-workflow.ts
+++ b/src/workflows/invoice-export-workflow.ts
@@ -5,6 +5,7 @@ import type { ExportDownloadResult, ExportExtractedResult, ExportResult, PollOpt
 import type { UnzipOptions } from '../utils/zip.js';
 import { unzip } from '../utils/zip.js';
 import { pollUntil } from './polling.js';
+import { verifyHash } from '../utils/hash.js';
 
 export interface ExportOptions {
   onlyMetadata?: boolean;
@@ -18,6 +19,8 @@ export interface ExportAndDownloadOptions extends ExportOptions {
   extract?: boolean;
   /** Options for ZIP extraction safety limits (only used when extract is true). */
   unzipOptions?: UnzipOptions;
+  /** Verify SHA-256 hash of encrypted parts after download. Defaults to true. */
+  verifyHash?: boolean;
 }
 
 export async function doExport(
@@ -56,6 +59,7 @@ export async function doExport(
         url: p.url,
         method: p.method,
         partSize: p.partSize,
+        partHash: p.partHash,
         encryptedPartSize: p.encryptedPartSize,
         encryptedPartHash: p.encryptedPartHash,
         expirationDate: p.expirationDate,
@@ -103,6 +107,9 @@ export async function exportAndDownload(
       throw new Error(`Download failed for part ${part.ordinalNumber}: HTTP ${resp.status}`);
     }
     const encryptedData = new Uint8Array(await resp.arrayBuffer());
+    if (options?.verifyHash !== false && !verifyHash(encryptedData, part.encryptedPartHash)) {
+      throw new Error(`Hash mismatch for export part ${part.ordinalNumber}`);
+    }
     const decrypted = client.crypto.decryptAES256(encryptedData, encData.cipherKey, encData.cipherIv);
     decryptedParts.push(decrypted);
   }

--- a/src/workflows/online-session-workflow.ts
+++ b/src/workflows/online-session-workflow.ts
@@ -3,6 +3,9 @@ import type { UpoVersion } from '../http/ksef-feature.js';
 import type { FormCode } from '../models/common.js';
 import type { OnlineSessionState } from '../models/sessions/session-state.js';
 import { KSeFSessionExpiredError } from '../errors/ksef-session-expired-error.js';
+import { DefaultAuthManager } from '../http/auth-manager.js';
+import { OnlineSessionService } from '../services/online-session.js';
+import { SessionStatusService } from '../services/session-status.js';
 import { DEFAULT_FORM_CODE } from '../models/document-structures/index.js';
 import type { OnlineSessionHandle, ParsedUpoInfo, PollOptions, UpoInfo } from './types.js';
 import { pollUntil } from './polling.js';
@@ -21,8 +24,15 @@ export interface SendAndCloseOptions extends OpenOnlineSessionOptions {
   pollOptions?: PollOptions;
 }
 
+interface SessionHandleDeps {
+  crypto: { getFileMetadata(data: Uint8Array): { hashSHA: string; fileSize: number }; encryptAES256(data: Uint8Array, key: Uint8Array, iv: Uint8Array): Uint8Array };
+  onlineSession: Pick<OnlineSessionService, 'sendInvoice' | 'closeSession'>;
+  sessionStatus: Pick<SessionStatusService, 'getSessionStatus' | 'getSessionUpo'>;
+  getAccessToken: () => string | undefined;
+}
+
 interface SessionHandleParams {
-  client: KSeFClient;
+  deps: SessionHandleDeps;
   sessionRef: string;
   validUntil: string;
   cipherKey: Uint8Array;
@@ -32,11 +42,11 @@ interface SessionHandleParams {
 }
 
 function buildSessionHandle(params: SessionHandleParams): OnlineSessionHandle {
-  const { client, sessionRef, validUntil, cipherKey, cipherIv, formCode, validate } = params;
+  const { deps, sessionRef, validUntil, cipherKey, cipherIv, formCode, validate } = params;
 
   async function fetchUpo(pollOpts?: PollOptions): Promise<UpoInfo> {
     const result = await pollUntil(
-      () => client.sessionStatus.getSessionStatus(sessionRef),
+      () => deps.sessionStatus.getSessionStatus(sessionRef),
       (s) => s.status.code === 200 || s.status.code >= 400,
       { ...pollOpts, description: `UPO for session ${sessionRef}` },
     );
@@ -67,11 +77,11 @@ function buildSessionHandle(params: SessionHandleParams): OnlineSessionHandle {
         }
       }
       const data = typeof invoiceXml === 'string' ? new TextEncoder().encode(invoiceXml) : invoiceXml;
-      const plainMeta = client.crypto.getFileMetadata(data);
-      const encrypted = client.crypto.encryptAES256(data, cipherKey, cipherIv);
-      const encMeta = client.crypto.getFileMetadata(encrypted);
+      const plainMeta = deps.crypto.getFileMetadata(data);
+      const encrypted = deps.crypto.encryptAES256(data, cipherKey, cipherIv);
+      const encMeta = deps.crypto.getFileMetadata(encrypted);
 
-      const resp = await client.onlineSession.sendInvoice(sessionRef, {
+      const resp = await deps.onlineSession.sendInvoice(sessionRef, {
         invoiceHash: plainMeta.hashSHA,
         invoiceSize: plainMeta.fileSize,
         encryptedInvoiceHash: encMeta.hashSHA,
@@ -82,7 +92,7 @@ function buildSessionHandle(params: SessionHandleParams): OnlineSessionHandle {
     },
 
     async close(): Promise<void> {
-      await client.onlineSession.closeSession(sessionRef);
+      await deps.onlineSession.closeSession(sessionRef);
     },
 
     async waitForUpo(pollOpts?: PollOptions): Promise<UpoInfo> {
@@ -93,14 +103,14 @@ function buildSessionHandle(params: SessionHandleParams): OnlineSessionHandle {
       const upoInfo = await fetchUpo(pollOpts);
       const parsed = [];
       for (const page of upoInfo.pages) {
-        const result = await client.sessionStatus.getSessionUpo(sessionRef, page.referenceNumber);
+        const result = await deps.sessionStatus.getSessionUpo(sessionRef, page.referenceNumber);
         parsed.push(parseUpoXml(result.upo));
       }
       return { ...upoInfo, parsed };
     },
 
     getState(): OnlineSessionState {
-      const token = client.authManager.getAccessToken();
+      const token = deps.getAccessToken();
       if (!token) {
         throw new Error('Cannot serialize session state: no access token available');
       }
@@ -130,7 +140,12 @@ export async function openOnlineSession(
   );
 
   return buildSessionHandle({
-    client,
+    deps: {
+      crypto: client.crypto,
+      onlineSession: client.onlineSession,
+      sessionStatus: client.sessionStatus,
+      getAccessToken: () => client.authManager.getAccessToken(),
+    },
     sessionRef: openResp.referenceNumber,
     validUntil: openResp.validUntil,
     cipherKey: encData.cipherKey,
@@ -152,10 +167,16 @@ export function resumeOnlineSession(
     );
   }
 
-  client.authManager.setAccessToken(state.accessToken);
+  const scopedAuth = new DefaultAuthManager(() => Promise.resolve(null), state.accessToken);
+  const scopedRestClient = client.createScopedRestClient(scopedAuth);
 
   return buildSessionHandle({
-    client,
+    deps: {
+      crypto: client.crypto,
+      onlineSession: new OnlineSessionService(scopedRestClient),
+      sessionStatus: new SessionStatusService(scopedRestClient),
+      getAccessToken: () => scopedAuth.getAccessToken(),
+    },
     sessionRef: state.referenceNumber,
     validUntil: state.validUntil,
     cipherKey: new Uint8Array(Buffer.from(state.aesKey, 'base64')),

--- a/src/workflows/online-session-workflow.ts
+++ b/src/workflows/online-session-workflow.ts
@@ -121,6 +121,7 @@ function buildSessionHandle(params: SessionHandleParams): OnlineSessionHandle {
         accessToken: token,
         formCode,
         validUntil,
+        ...(validate ? { validate } : {}),
       };
     },
   };
@@ -182,7 +183,7 @@ export function resumeOnlineSession(
     cipherKey: new Uint8Array(Buffer.from(state.aesKey, 'base64')),
     cipherIv: new Uint8Array(Buffer.from(state.iv, 'base64')),
     formCode: state.formCode,
-    validate: options?.validate,
+    validate: options?.validate ?? state.validate,
   });
 }
 

--- a/src/workflows/online-session-workflow.ts
+++ b/src/workflows/online-session-workflow.ts
@@ -2,6 +2,7 @@ import type { KSeFClient } from '../client.js';
 import type { UpoVersion } from '../http/ksef-feature.js';
 import type { FormCode } from '../models/common.js';
 import type { OnlineSessionState } from '../models/sessions/session-state.js';
+import { KSeFSessionExpiredError } from '../errors/ksef-session-expired-error.js';
 import { DEFAULT_FORM_CODE } from '../models/document-structures/index.js';
 import type { OnlineSessionHandle, ParsedUpoInfo, PollOptions, UpoInfo } from './types.js';
 import { pollUntil } from './polling.js';
@@ -99,11 +100,15 @@ function buildSessionHandle(params: SessionHandleParams): OnlineSessionHandle {
     },
 
     getState(): OnlineSessionState {
+      const token = client.authManager.getAccessToken();
+      if (!token) {
+        throw new Error('Cannot serialize session state: no access token available');
+      }
       return {
         referenceNumber: sessionRef,
         aesKey: Buffer.from(cipherKey).toString('base64'),
         iv: Buffer.from(cipherIv).toString('base64'),
-        accessToken: client.authManager.getAccessToken()!,
+        accessToken: token,
         formCode,
         validUntil,
       };
@@ -140,6 +145,13 @@ export function resumeOnlineSession(
   state: OnlineSessionState,
   options?: Pick<OpenOnlineSessionOptions, 'validate'>,
 ): OnlineSessionHandle {
+  const expiry = new Date(state.validUntil);
+  if (expiry.getTime() <= Date.now()) {
+    throw new KSeFSessionExpiredError(
+      `Cannot resume session: expired at ${state.validUntil}`,
+    );
+  }
+
   client.authManager.setAccessToken(state.accessToken);
 
   return buildSessionHandle({

--- a/src/workflows/online-session-workflow.ts
+++ b/src/workflows/online-session-workflow.ts
@@ -1,6 +1,7 @@
 import type { KSeFClient } from '../client.js';
 import type { UpoVersion } from '../http/ksef-feature.js';
 import type { FormCode } from '../models/common.js';
+import type { OnlineSessionState } from '../models/sessions/session-state.js';
 import { DEFAULT_FORM_CODE } from '../models/document-structures/index.js';
 import type { OnlineSessionHandle, ParsedUpoInfo, PollOptions, UpoInfo } from './types.js';
 import { pollUntil } from './polling.js';
@@ -19,21 +20,18 @@ export interface SendAndCloseOptions extends OpenOnlineSessionOptions {
   pollOptions?: PollOptions;
 }
 
-export async function openOnlineSession(
-  client: KSeFClient,
-  options?: OpenOnlineSessionOptions,
-): Promise<OnlineSessionHandle> {
-  await client.crypto.init();
-  // KSeF provides a single (key, IV) pair per session — all invoices share it.
-  const encData = client.crypto.getEncryptionData();
-  const formCode = options?.formCode ?? DEFAULT_FORM_CODE;
+interface SessionHandleParams {
+  client: KSeFClient;
+  sessionRef: string;
+  validUntil: string;
+  cipherKey: Uint8Array;
+  cipherIv: Uint8Array;
+  formCode: FormCode;
+  validate?: boolean;
+}
 
-  const openResp = await client.onlineSession.openSession(
-    { formCode, encryption: encData.encryptionInfo },
-    options?.upoVersion,
-  );
-
-  const sessionRef = openResp.referenceNumber;
+function buildSessionHandle(params: SessionHandleParams): OnlineSessionHandle {
+  const { client, sessionRef, validUntil, cipherKey, cipherIv, formCode, validate } = params;
 
   async function fetchUpo(pollOpts?: PollOptions): Promise<UpoInfo> {
     const result = await pollUntil(
@@ -54,10 +52,10 @@ export async function openOnlineSession(
 
   return {
     sessionRef,
-    validUntil: openResp.validUntil,
+    validUntil,
 
     async sendInvoice(invoiceXml: string | Uint8Array): Promise<string> {
-      if (options?.validate) {
+      if (validate) {
         const xmlStr = typeof invoiceXml === 'string' ? invoiceXml : new TextDecoder().decode(invoiceXml);
         const vResult = await validateInvoice(xmlStr);
         if (!vResult.valid) {
@@ -69,7 +67,7 @@ export async function openOnlineSession(
       }
       const data = typeof invoiceXml === 'string' ? new TextEncoder().encode(invoiceXml) : invoiceXml;
       const plainMeta = client.crypto.getFileMetadata(data);
-      const encrypted = client.crypto.encryptAES256(data, encData.cipherKey, encData.cipherIv);
+      const encrypted = client.crypto.encryptAES256(data, cipherKey, cipherIv);
       const encMeta = client.crypto.getFileMetadata(encrypted);
 
       const resp = await client.onlineSession.sendInvoice(sessionRef, {
@@ -99,7 +97,60 @@ export async function openOnlineSession(
       }
       return { ...upoInfo, parsed };
     },
+
+    getState(): OnlineSessionState {
+      return {
+        referenceNumber: sessionRef,
+        aesKey: Buffer.from(cipherKey).toString('base64'),
+        iv: Buffer.from(cipherIv).toString('base64'),
+        accessToken: client.authManager.getAccessToken()!,
+        formCode,
+        validUntil,
+      };
+    },
   };
+}
+
+export async function openOnlineSession(
+  client: KSeFClient,
+  options?: OpenOnlineSessionOptions,
+): Promise<OnlineSessionHandle> {
+  await client.crypto.init();
+  const encData = client.crypto.getEncryptionData();
+  const formCode = options?.formCode ?? DEFAULT_FORM_CODE;
+
+  const openResp = await client.onlineSession.openSession(
+    { formCode, encryption: encData.encryptionInfo },
+    options?.upoVersion,
+  );
+
+  return buildSessionHandle({
+    client,
+    sessionRef: openResp.referenceNumber,
+    validUntil: openResp.validUntil,
+    cipherKey: encData.cipherKey,
+    cipherIv: encData.cipherIv,
+    formCode,
+    validate: options?.validate,
+  });
+}
+
+export function resumeOnlineSession(
+  client: KSeFClient,
+  state: OnlineSessionState,
+  options?: Pick<OpenOnlineSessionOptions, 'validate'>,
+): OnlineSessionHandle {
+  client.authManager.setAccessToken(state.accessToken);
+
+  return buildSessionHandle({
+    client,
+    sessionRef: state.referenceNumber,
+    validUntil: state.validUntil,
+    cipherKey: new Uint8Array(Buffer.from(state.aesKey, 'base64')),
+    cipherIv: new Uint8Array(Buffer.from(state.iv, 'base64')),
+    formCode: state.formCode,
+    validate: options?.validate,
+  });
 }
 
 export async function openSendAndClose(

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -1,4 +1,5 @@
 import type { UpoPotwierdzenie } from '../xml/index.js';
+import type { OnlineSessionState } from '../models/sessions/session-state.js';
 
 export interface PollOptions {
   intervalMs?: number;
@@ -13,6 +14,8 @@ export interface OnlineSessionHandle {
   close(): Promise<void>;
   waitForUpo(options?: PollOptions): Promise<UpoInfo>;
   waitForUpoParsed(options?: PollOptions): Promise<ParsedUpoInfo>;
+  /** Serialize session state for persistence. Restore with `resumeOnlineSession()`. */
+  getState(): OnlineSessionState;
 }
 
 export interface UpoInfo {

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -42,6 +42,7 @@ export interface ExportResult {
     url: string;
     method: string;
     partSize: number;
+    partHash: string;
     encryptedPartSize: number;
     encryptedPartHash: string;
     expirationDate: string;

--- a/tests/e2e/04-session-online.test.ts
+++ b/tests/e2e/04-session-online.test.ts
@@ -85,7 +85,7 @@ describe('04 - Online Session E2E', { timeout: 180_000 }, () => {
     expect(sessionUpo.upo).toBeTruthy();
 
     // Step 10: Get invoice XML by KSeF number
-    const invoiceXml = await client.invoices.getInvoice(ksefNumber);
+    const { xml: invoiceXml } = await client.invoices.getInvoice(ksefNumber);
     expect(invoiceXml).toContain(nip);
     expect(invoiceXml).toContain('Faktura');
 

--- a/tests/e2e/06-invoices.test.ts
+++ b/tests/e2e/06-invoices.test.ts
@@ -58,7 +58,7 @@ describe('06 - Invoice Query & Export', { timeout: 300_000 }, () => {
   });
 
   it('should get invoice by KSeF number', async () => {
-    const xml = await client.invoices.getInvoice(sentKsefNumber);
+    const { xml } = await client.invoices.getInvoice(sentKsefNumber);
     expect(xml).toContain('Faktura');
     expect(xml).toContain(sentNip);
   });

--- a/tests/e2e/23-workflow-incremental-export.test.ts
+++ b/tests/e2e/23-workflow-incremental-export.test.ts
@@ -12,6 +12,16 @@ import { InMemoryHwmStore } from '../../src/workflows/hwm-storage.js';
 
 const EXPORT_POLL = { intervalMs: 2000, maxAttempts: 120 };
 
+/**
+ * KSeF assigns PermanentStorage dates in CET/CEST (Europe/Warsaw).
+ * Compute date strings in Polish timezone so export filters align with
+ * KSeF regardless of where the test runner is located (CI uses UTC).
+ */
+function dateInCET(offsetDays: number): string {
+  const d = new Date(Date.now() + offsetDays * 86_400_000);
+  return d.toLocaleDateString('sv-SE', { timeZone: 'Europe/Warsaw' });
+}
+
 describe('23 - Incremental Export Workflow', { timeout: 300_000 }, () => {
   let client: KSeFClient;
   let nip: string;
@@ -29,7 +39,7 @@ describe('23 - Incremental Export Workflow', { timeout: 300_000 }, () => {
     });
 
     // Wait for invoices to reach PermanentStorage index (used by incremental export)
-    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+    const yesterday = dateInCET(-1);
     const permStorageFilters = new InvoiceQueryFilterBuilder()
       .withSubjectType('Subject1')
       .withDateRange('PermanentStorage', yesterday)
@@ -43,8 +53,8 @@ describe('23 - Incremental Export Workflow', { timeout: 300_000 }, () => {
   }, 180_000);
 
   it('should perform incremental export and return results', async () => {
-    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
-    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+    const yesterday = dateInCET(-1);
+    const tomorrow = dateInCET(+1);
     const continuationPoints: ContinuationPoints = {};
 
     const result = await incrementalExportAndDownload(client, {
@@ -69,8 +79,8 @@ describe('23 - Incremental Export Workflow', { timeout: 300_000 }, () => {
   });
 
   it('should work with HwmStore', async () => {
-    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
-    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+    const yesterday = dateInCET(-1);
+    const tomorrow = dateInCET(+1);
     const store = new InMemoryHwmStore();
     const continuationPoints: ContinuationPoints = {};
 
@@ -91,8 +101,8 @@ describe('23 - Incremental Export Workflow', { timeout: 300_000 }, () => {
   });
 
   it('should advance continuation points after export', async () => {
-    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
-    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+    const yesterday = dateInCET(-1);
+    const tomorrow = dateInCET(+1);
     const continuationPoints: ContinuationPoints = {};
 
     const result = await incrementalExportAndDownload(client, {
@@ -114,8 +124,8 @@ describe('23 - Incremental Export Workflow', { timeout: 300_000 }, () => {
   });
 
   it('should extract invoice XML from decrypted ZIP parts', async () => {
-    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
-    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+    const yesterday = dateInCET(-1);
+    const tomorrow = dateInCET(+1);
 
     const result = await incrementalExportAndDownload(client, {
       subjectType: 'Subject1',
@@ -145,8 +155,8 @@ describe('23 - Incremental Export Workflow', { timeout: 300_000 }, () => {
   });
 
   it('should deduplicate invoices from overlapping exports', async () => {
-    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
-    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+    const yesterday = dateInCET(-1);
+    const tomorrow = dateInCET(+1);
 
     // Run two exports with the same date window — both will return the same invoices
     const [resultA, resultB] = await Promise.all([
@@ -201,8 +211,8 @@ describe('23 - Incremental Export Workflow', { timeout: 300_000 }, () => {
   });
 
   it('should invoke onIterationComplete callback', async () => {
-    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
-    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+    const yesterday = dateInCET(-1);
+    const tomorrow = dateInCET(+1);
     const iterations: Array<{ i: number; r: ExportResult }> = [];
 
     const result = await incrementalExportAndDownload(client, {

--- a/tests/unit/cli/commands/invoice.test.ts
+++ b/tests/unit/cli/commands/invoice.test.ts
@@ -473,6 +473,17 @@ describe('invoice', () => {
         { json: true },
       );
     });
+
+    it('outputs JSON without hash when hash is absent', async () => {
+      mockClient.invoices.getInvoice.mockResolvedValue({ xml: '<invoice/>' });
+
+      await runGet({ ksefNumber: 'KSeF-789', json: true });
+
+      expect(output.outputResult).toHaveBeenCalledWith(
+        { ksefNumber: 'KSeF-789', xml: '<invoice/>' },
+        { json: true },
+      );
+    });
   });
 
   describe('export', () => {

--- a/tests/unit/cli/commands/invoice.test.ts
+++ b/tests/unit/cli/commands/invoice.test.ts
@@ -184,7 +184,7 @@ describe('invoice', () => {
 
   describe('get', () => {
     it('calls getInvoice with ksefNumber', async () => {
-      mockClient.invoices.getInvoice.mockResolvedValue('<invoice/>');
+      mockClient.invoices.getInvoice.mockResolvedValue({ xml: '<invoice/>', hash: 'h1' });
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
       await runGet({ ksefNumber: 'KSeF-123' });
       expect(mockClient.invoices.getInvoice).toHaveBeenCalledWith('KSeF-123');
@@ -192,7 +192,7 @@ describe('invoice', () => {
     });
 
     it('writes to file when --output is provided', async () => {
-      mockClient.invoices.getInvoice.mockResolvedValue('<invoice/>');
+      mockClient.invoices.getInvoice.mockResolvedValue({ xml: '<invoice/>' });
       await runGet({ ksefNumber: 'KSeF-123', o: '/out.xml' });
       expect(fs.writeFileSync).toHaveBeenCalledWith('/out.xml', '<invoice/>', 'utf-8');
     });
@@ -464,12 +464,12 @@ describe('invoice', () => {
 
   describe('get — JSON mode', () => {
     it('outputs JSON when --json is set', async () => {
-      mockClient.invoices.getInvoice.mockResolvedValue('<invoice/>');
+      mockClient.invoices.getInvoice.mockResolvedValue({ xml: '<invoice/>', hash: 'h1' });
 
       await runGet({ ksefNumber: 'KSeF-456', json: true });
 
       expect(output.outputResult).toHaveBeenCalledWith(
-        { ksefNumber: 'KSeF-456', xml: '<invoice/>' },
+        { ksefNumber: 'KSeF-456', xml: '<invoice/>', hash: 'h1' },
         { json: true },
       );
     });

--- a/tests/unit/offline/deadline.test.ts
+++ b/tests/unit/offline/deadline.test.ts
@@ -57,6 +57,30 @@ describe('nextBusinessDay', () => {
     const result = nextBusinessDay(new Date('2026-04-12T00:00:00Z'));
     expect(result.toISOString().slice(0, 10)).toBe('2026-04-13');
   });
+
+  it('skips Christmas cluster (Wed Dec 23 → Mon Dec 28)', () => {
+    // 2026: Dec 24 Thu (Wigilia), Dec 25 Fri (hol), Dec 26 Sat, Dec 27 Sun → Dec 28 Mon
+    const result = nextBusinessDay(new Date('2026-12-23T00:00:00Z'));
+    expect(result.toISOString().slice(0, 10)).toBe('2026-12-28');
+  });
+
+  it('skips Corpus Christi (Wed Jun 3 → Fri Jun 5, skips Thu Jun 4)', () => {
+    // 2026: Corpus Christi = Thu Jun 4
+    const result = nextBusinessDay(new Date('2026-06-03T00:00:00Z'));
+    expect(result.toISOString().slice(0, 10)).toBe('2026-06-05');
+  });
+
+  it('skips Easter Monday (Sun Apr 5 Easter → Tue Apr 7, skips Mon Apr 6)', () => {
+    // 2026: Easter Sunday = Apr 5, Easter Monday = Apr 6
+    const result = nextBusinessDay(new Date('2026-04-05T00:00:00Z'));
+    expect(result.toISOString().slice(0, 10)).toBe('2026-04-07');
+  });
+
+  it('skips Jan 6 Trzech Króli (Mon Jan 5 → Wed Jan 7)', () => {
+    // 2026: Jan 6 = Tuesday
+    const result = nextBusinessDay(new Date('2026-01-05T00:00:00Z'));
+    expect(result.toISOString().slice(0, 10)).toBe('2026-01-07');
+  });
 });
 
 describe('addBusinessDays', () => {
@@ -95,6 +119,18 @@ describe('addBusinessDays', () => {
     expect(() => addBusinessDays(new Date('2026-04-08T00:00:00Z'), NaN))
       .toThrow('days must be a non-negative integer, got NaN');
   });
+
+  it('skips holidays when adding business days (Dec 2026 cluster)', () => {
+    // Wed Dec 23 + 1bd: skip Dec 24 Thu (Wigilia), Dec 25 Fri (hol), Dec 26 Sat, Dec 27 Sun → Mon Dec 28
+    const result = addBusinessDays(new Date('2026-12-23T00:00:00Z'), 1);
+    expect(result.toISOString().slice(0, 10)).toBe('2026-12-28');
+  });
+
+  it('adds 7 business days across Corpus Christi', () => {
+    // Mon Jun 1 + 7bd: Tue 2, Wed 3, (Thu 4 = Corpus Christi skip), Fri 5, Mon 8, Tue 9, Wed 10
+    const result = addBusinessDays(new Date('2026-06-01T00:00:00Z'), 7);
+    expect(result.toISOString().slice(0, 10)).toBe('2026-06-11');
+  });
 });
 
 describe('calculateOfflineDeadline', () => {
@@ -118,6 +154,16 @@ describe('calculateOfflineDeadline', () => {
     it('accepts Date object', () => {
       const result = calculateOfflineDeadline('offline24', new Date('2026-04-08T12:00:00Z'));
       expect(result.toISOString().slice(0, 10)).toBe('2026-04-09');
+    });
+
+    it('skips Christmas cluster — Wed Dec 23 → Mon Dec 28 (Dec 24 Wigilia + Dec 25 hol + weekend)', () => {
+      const result = calculateOfflineDeadline('offline24', '2026-12-23');
+      expect(result.toISOString().slice(0, 10)).toBe('2026-12-28');
+    });
+
+    it('skips Easter Monday — Easter Sunday Apr 5 → Tue Apr 7', () => {
+      const result = calculateOfflineDeadline('offline24', '2026-04-05');
+      expect(result.toISOString().slice(0, 10)).toBe('2026-04-07');
     });
   });
 

--- a/tests/unit/offline/holidays.test.ts
+++ b/tests/unit/offline/holidays.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeEasterSunday,
+  getPolishHolidays,
+  isPolishHoliday,
+} from '../../../src/offline/holidays.js';
+
+describe('computeEasterSunday', () => {
+  const knownDates: [number, string][] = [
+    [2024, '2024-03-31'],
+    [2025, '2025-04-20'],
+    [2026, '2026-04-05'],
+    [2027, '2027-03-28'],
+    [2028, '2028-04-16'],
+    [2029, '2029-04-01'],
+    [2030, '2030-04-21'],
+  ];
+
+  it.each(knownDates)('returns correct date for %i', (year, expected) => {
+    const result = computeEasterSunday(year);
+    expect(result.toISOString().slice(0, 10)).toBe(expected);
+  });
+
+  it('returns a Sunday', () => {
+    for (let y = 2020; y <= 2035; y++) {
+      expect(computeEasterSunday(y).getUTCDay()).toBe(0);
+    }
+  });
+});
+
+describe('getPolishHolidays', () => {
+  it('returns 14 holidays for 2026 (includes Wigilia since 2025)', () => {
+    expect(getPolishHolidays(2026).size).toBe(14);
+  });
+
+  it('returns 13 holidays for 2024 (before Wigilia amendment)', () => {
+    expect(getPolishHolidays(2024).size).toBe(13);
+  });
+
+  it('includes all fixed holidays', () => {
+    const holidays = getPolishHolidays(2026);
+    expect(holidays.has('2026-01-01')).toBe(true); // Nowy Rok
+    expect(holidays.has('2026-01-06')).toBe(true); // Trzech Kroli
+    expect(holidays.has('2026-05-01')).toBe(true); // Swieto Pracy
+    expect(holidays.has('2026-05-03')).toBe(true); // Konstytucja
+    expect(holidays.has('2026-08-15')).toBe(true); // Wniebowziecie
+    expect(holidays.has('2026-11-01')).toBe(true); // Wszystkich Swietych
+    expect(holidays.has('2026-11-11')).toBe(true); // Niepodleglosc
+    expect(holidays.has('2026-12-25')).toBe(true); // Boze Narodzenie 1
+    expect(holidays.has('2026-12-26')).toBe(true); // Boze Narodzenie 2
+  });
+
+  it('includes moveable holidays for 2026 (Easter Apr 5)', () => {
+    const holidays = getPolishHolidays(2026);
+    expect(holidays.has('2026-04-05')).toBe(true); // Easter Sunday
+    expect(holidays.has('2026-04-06')).toBe(true); // Easter Monday
+    expect(holidays.has('2026-05-24')).toBe(true); // Pentecost (Easter + 49)
+    expect(holidays.has('2026-06-04')).toBe(true); // Corpus Christi (Easter + 60)
+  });
+
+  it('includes moveable holidays for 2025 (Easter Apr 20)', () => {
+    const holidays = getPolishHolidays(2025);
+    expect(holidays.has('2025-04-20')).toBe(true); // Easter Sunday
+    expect(holidays.has('2025-04-21')).toBe(true); // Easter Monday
+    expect(holidays.has('2025-06-08')).toBe(true); // Pentecost (Easter + 49)
+    expect(holidays.has('2025-06-19')).toBe(true); // Corpus Christi
+  });
+
+  it('returns cached instance on repeated calls', () => {
+    const a = getPolishHolidays(2026);
+    const b = getPolishHolidays(2026);
+    expect(a).toBe(b);
+  });
+
+  it('returns correct holiday count for a range of years', () => {
+    for (let y = 2020; y <= 2024; y++) {
+      expect(getPolishHolidays(y).size).toBe(13);
+    }
+    for (let y = 2025; y <= 2035; y++) {
+      expect(getPolishHolidays(y).size).toBe(14);
+    }
+  });
+
+  it('includes Wigilia (Dec 24) for 2025+', () => {
+    expect(getPolishHolidays(2025).has('2025-12-24')).toBe(true);
+    expect(getPolishHolidays(2026).has('2026-12-24')).toBe(true);
+  });
+
+  it('does not include Wigilia (Dec 24) for 2024', () => {
+    expect(getPolishHolidays(2024).has('2024-12-24')).toBe(false);
+  });
+});
+
+describe('isPolishHoliday', () => {
+  it('returns true for Christmas Day', () => {
+    expect(isPolishHoliday(new Date('2026-12-25T00:00:00Z'))).toBe(true);
+  });
+
+  it('returns true for New Year', () => {
+    expect(isPolishHoliday(new Date('2026-01-01T12:00:00Z'))).toBe(true);
+  });
+
+  it('returns true for Easter Monday 2026', () => {
+    expect(isPolishHoliday(new Date('2026-04-06T00:00:00Z'))).toBe(true);
+  });
+
+  it('returns true for Corpus Christi 2026', () => {
+    expect(isPolishHoliday(new Date('2026-06-04T00:00:00Z'))).toBe(true);
+  });
+
+  it('returns false for a regular weekday', () => {
+    expect(isPolishHoliday(new Date('2026-03-10T00:00:00Z'))).toBe(false);
+  });
+
+  it('returns true for Christmas Eve 2026 (statutory since 2025)', () => {
+    expect(isPolishHoliday(new Date('2026-12-24T00:00:00Z'))).toBe(true);
+  });
+
+  it('returns false for Christmas Eve 2024 (before amendment)', () => {
+    expect(isPolishHoliday(new Date('2024-12-24T00:00:00Z'))).toBe(false);
+  });
+
+  it('returns false for Dec 27', () => {
+    expect(isPolishHoliday(new Date('2026-12-27T00:00:00Z'))).toBe(false);
+  });
+});

--- a/tests/unit/services/batch-session.test.ts
+++ b/tests/unit/services/batch-session.test.ts
@@ -160,7 +160,7 @@ describe('BatchSessionService', () => {
   it('sendParts throws on non-ok response from presigned URL', async () => {
     const client = createMockRestClient();
     const service = new BatchSessionService(client);
-    const mockFetch = vi.fn().mockResolvedValue(new Response('', { status: 403 }));
+    const mockFetch = vi.fn().mockResolvedValue(new Response('Access Denied', { status: 403 }));
     vi.stubGlobal('fetch', mockFetch);
 
     const openResponse = {
@@ -172,7 +172,7 @@ describe('BatchSessionService', () => {
     const parts = [{ ordinalNumber: 1, data: 'data-1' }] as any[];
 
     await expect(service.sendParts(openResponse, parts)).rejects.toThrow(
-      'Upload failed for part 1: HTTP 403',
+      'Upload failed for part 1: HTTP 403 — Access Denied',
     );
   });
 

--- a/tests/unit/services/batch-session.test.ts
+++ b/tests/unit/services/batch-session.test.ts
@@ -105,7 +105,7 @@ describe('BatchSessionService', () => {
     );
   });
 
-  it('sendParts uploads all parts in parallel', async () => {
+  it('sendParts uploads all parts in parallel by default', async () => {
     const client = createMockRestClient();
     const service = new BatchSessionService(client);
     const mockFetch = vi.fn().mockResolvedValue(new Response('', { status: 200 }));
@@ -126,6 +126,54 @@ describe('BatchSessionService', () => {
     await service.sendParts(openResponse, parts);
 
     expect(mockFetch.mock.calls.length).toBe(2);
+  });
+
+  it('sendParts with parallelism=1 uploads sequentially', async () => {
+    const client = createMockRestClient();
+    const service = new BatchSessionService(client);
+    const callOrder: number[] = [];
+    const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+      const ordinal = url.endsWith('part1') ? 1 : 2;
+      callOrder.push(ordinal);
+      await new Promise((r) => setTimeout(r, 10));
+      return new Response('', { status: 200 });
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const openResponse = {
+      referenceNumber: 'batch-ref',
+      partUploadRequests: [
+        { ordinalNumber: 1, url: 'https://presigned.url/part1', method: 'PUT', headers: {} },
+        { ordinalNumber: 2, url: 'https://presigned.url/part2', method: 'PUT', headers: {} },
+      ],
+    } as any;
+    const parts = [
+      { ordinalNumber: 1, data: 'data-1' },
+      { ordinalNumber: 2, data: 'data-2' },
+    ] as any[];
+
+    await service.sendParts(openResponse, parts, 1);
+
+    expect(callOrder).toEqual([1, 2]);
+  });
+
+  it('sendParts throws on non-ok response from presigned URL', async () => {
+    const client = createMockRestClient();
+    const service = new BatchSessionService(client);
+    const mockFetch = vi.fn().mockResolvedValue(new Response('', { status: 403 }));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const openResponse = {
+      referenceNumber: 'batch-ref',
+      partUploadRequests: [
+        { ordinalNumber: 1, url: 'https://presigned.url/part1', method: 'PUT', headers: {} },
+      ],
+    } as any;
+    const parts = [{ ordinalNumber: 1, data: 'data-1' }] as any[];
+
+    await expect(service.sendParts(openResponse, parts)).rejects.toThrow(
+      'Upload failed for part 1: HTTP 403',
+    );
   });
 
   it('sendPartsWithStream uploads parts sequentially (not concurrent)', async () => {
@@ -160,6 +208,41 @@ describe('BatchSessionService', () => {
     // Sequential: part 1 completes before part 2 starts
     expect(callOrder).toEqual([1, 2]);
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('sendPartsWithStream with parallelism=2 uses bounded concurrency', async () => {
+    const client = createMockRestClient();
+    const service = new BatchSessionService(client);
+    let active = 0;
+    let maxActive = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 10));
+      active--;
+      return new Response('', { status: 200 });
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const openResponse = {
+      referenceNumber: 'batch-ref',
+      partUploadRequests: [
+        { ordinalNumber: 1, url: 'https://presigned.url/part1', method: 'PUT', headers: {} },
+        { ordinalNumber: 2, url: 'https://presigned.url/part2', method: 'PUT', headers: {} },
+        { ordinalNumber: 3, url: 'https://presigned.url/part3', method: 'PUT', headers: {} },
+        { ordinalNumber: 4, url: 'https://presigned.url/part4', method: 'PUT', headers: {} },
+      ],
+    } as any;
+
+    const makeStream = () => new ReadableStream({ start(c) { c.enqueue(new Uint8Array([1])); c.close(); } });
+    const parts = [1, 2, 3, 4].map((n) => ({
+      ordinalNumber: n, dataStream: makeStream(), metadata: { hashSHA: 'h', fileSize: 1 },
+    }));
+
+    await service.sendPartsWithStream(openResponse, parts, 2);
+
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    expect(maxActive).toBeLessThanOrEqual(2);
   });
 
   it('sendPartsWithStream throws on ordinal mismatch', async () => {

--- a/tests/unit/services/batch-session.test.ts
+++ b/tests/unit/services/batch-session.test.ts
@@ -72,16 +72,18 @@ describe('BatchSessionService', () => {
 
     await service.sendParts(openResponse, parts);
 
-    expect(mockFetch).toHaveBeenCalledWith('https://presigned.url/part1', {
+    expect(mockFetch).toHaveBeenCalledWith('https://presigned.url/part1', expect.objectContaining({
       method: 'PUT',
       headers: { 'x-custom': 'val1' },
       body: 'data-part-1',
-    });
-    expect(mockFetch).toHaveBeenCalledWith('https://presigned.url/part2', {
+      signal: expect.any(AbortSignal),
+    }));
+    expect(mockFetch).toHaveBeenCalledWith('https://presigned.url/part2', expect.objectContaining({
       method: 'PUT',
       headers: { 'x-custom': 'val2' },
       body: 'data-part-2',
-    });
+      signal: expect.any(AbortSignal),
+    }));
   });
 
   it('sendParts throws when part ordinalNumber not found in partUploadRequests', async () => {

--- a/tests/unit/services/invoice-download.test.ts
+++ b/tests/unit/services/invoice-download.test.ts
@@ -3,14 +3,28 @@ import { Routes } from '../../../src/http/routes.js';
 import { createMockRestClient, getRequest, mockResponse, mockRawResponse } from './_helpers.js';
 
 describe('InvoiceDownloadService', () => {
-  it('getInvoice uses executeRaw and decodes ArrayBuffer to string', async () => {
+  it('getInvoice returns xml and hash from response headers', async () => {
+    const client = createMockRestClient();
+    const service = new InvoiceDownloadService(client);
+    (client.executeRaw as any).mockResolvedValueOnce(
+      mockRawResponse('<invoice-xml/>', { 'x-ms-meta-hash': 'abc123hash' }),
+    );
+
+    const result = await service.getInvoice('KSeF-123');
+
+    expect(result.xml).toBe('<invoice-xml/>');
+    expect(result.hash).toBe('abc123hash');
+  });
+
+  it('getInvoice returns undefined hash when header is missing', async () => {
     const client = createMockRestClient();
     const service = new InvoiceDownloadService(client);
     (client.executeRaw as any).mockResolvedValueOnce(mockRawResponse('<invoice-xml/>'));
 
     const result = await service.getInvoice('KSeF-123');
 
-    expect(result).toBe('<invoice-xml/>');
+    expect(result.xml).toBe('<invoice-xml/>');
+    expect(result.hash).toBeUndefined();
   });
 
   it('queryInvoiceMetadata sends POST with filters body and no query params', async () => {

--- a/tests/unit/utils/concurrency.test.ts
+++ b/tests/unit/utils/concurrency.test.ts
@@ -7,7 +7,7 @@ describe('runWithConcurrency', () => {
 
   it('executes all tasks with parallelism=1 sequentially', async () => {
     const order: number[] = [];
-    const tasks = [1, 2, 3].map((n) => async () => {
+    const tasks = [1, 2, 3].map((n) => async (_signal: AbortSignal) => {
       order.push(n);
       await new Promise((r) => setTimeout(r, 5));
     });
@@ -19,7 +19,7 @@ describe('runWithConcurrency', () => {
   it('executes all tasks concurrently when parallelism >= task count', async () => {
     let active = 0;
     let maxActive = 0;
-    const tasks = Array.from({ length: 3 }, () => async () => {
+    const tasks = Array.from({ length: 3 }, () => async (_signal: AbortSignal) => {
       active++;
       maxActive = Math.max(maxActive, active);
       await new Promise((r) => setTimeout(r, 10));
@@ -33,7 +33,7 @@ describe('runWithConcurrency', () => {
   it('respects bounded concurrency with parallelism=2', async () => {
     let active = 0;
     let maxActive = 0;
-    const tasks = Array.from({ length: 5 }, () => async () => {
+    const tasks = Array.from({ length: 5 }, () => async (_signal: AbortSignal) => {
       active++;
       maxActive = Math.max(maxActive, active);
       await new Promise((r) => setTimeout(r, 10));
@@ -47,7 +47,7 @@ describe('runWithConcurrency', () => {
   it('clamps parallelism=0 to 1 (sequential)', async () => {
     let active = 0;
     let maxActive = 0;
-    const tasks = Array.from({ length: 3 }, () => async () => {
+    const tasks = Array.from({ length: 3 }, () => async (_signal: AbortSignal) => {
       active++;
       maxActive = Math.max(maxActive, active);
       await new Promise((r) => setTimeout(r, 5));
@@ -60,9 +60,9 @@ describe('runWithConcurrency', () => {
 
   it('propagates error from a failing task', async () => {
     const tasks = [
-      async () => {},
-      async () => { throw new Error('boom'); },
-      async () => {},
+      async (_signal: AbortSignal) => {},
+      async (_signal: AbortSignal) => { throw new Error('boom'); },
+      async (_signal: AbortSignal) => {},
     ];
 
     await expect(runWithConcurrency(tasks, 2)).rejects.toThrow('boom');
@@ -70,7 +70,7 @@ describe('runWithConcurrency', () => {
 
   it('stops scheduling new tasks after first error', async () => {
     const executed: number[] = [];
-    const tasks = Array.from({ length: 20 }, (_, i) => async () => {
+    const tasks = Array.from({ length: 20 }, (_, i) => async (_signal: AbortSignal) => {
       executed.push(i);
       if (i === 2) throw new Error('fail');
       await new Promise((r) => setTimeout(r, 5));
@@ -80,9 +80,29 @@ describe('runWithConcurrency', () => {
     expect(executed.length).toBeLessThan(20);
   });
 
+  it('passes AbortSignal to tasks and aborts on failure', async () => {
+    const signals: AbortSignal[] = [];
+    const tasks = [
+      async (signal: AbortSignal) => {
+        signals.push(signal);
+        await new Promise((r) => setTimeout(r, 50));
+      },
+      async (signal: AbortSignal) => {
+        signals.push(signal);
+        throw new Error('abort-test');
+      },
+    ];
+
+    await expect(runWithConcurrency(tasks, 2)).rejects.toThrow('abort-test');
+    expect(signals).toHaveLength(2);
+    // After error, signal should be aborted
+    expect(signals[0]!.aborted).toBe(true);
+    expect(signals[1]!.aborted).toBe(true);
+  });
+
   it('executes all tasks exactly once', async () => {
     const calls: number[] = [];
-    const tasks = [1, 2, 3, 4, 5].map((n) => async () => {
+    const tasks = [1, 2, 3, 4, 5].map((n) => async (_signal: AbortSignal) => {
       calls.push(n);
     });
 

--- a/tests/unit/utils/concurrency.test.ts
+++ b/tests/unit/utils/concurrency.test.ts
@@ -1,0 +1,80 @@
+import { runWithConcurrency } from '../../../src/utils/concurrency.js';
+
+describe('runWithConcurrency', () => {
+  it('resolves immediately for empty task array', async () => {
+    await runWithConcurrency([], 5);
+  });
+
+  it('executes all tasks with parallelism=1 sequentially', async () => {
+    const order: number[] = [];
+    const tasks = [1, 2, 3].map((n) => async () => {
+      order.push(n);
+      await new Promise((r) => setTimeout(r, 5));
+    });
+
+    await runWithConcurrency(tasks, 1);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('executes all tasks concurrently when parallelism >= task count', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const tasks = Array.from({ length: 3 }, () => async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 10));
+      active--;
+    });
+
+    await runWithConcurrency(tasks, 10);
+    expect(maxActive).toBe(3);
+  });
+
+  it('respects bounded concurrency with parallelism=2', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const tasks = Array.from({ length: 5 }, () => async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 10));
+      active--;
+    });
+
+    await runWithConcurrency(tasks, 2);
+    expect(maxActive).toBe(2);
+  });
+
+  it('clamps parallelism=0 to 1 (sequential)', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const tasks = Array.from({ length: 3 }, () => async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 5));
+      active--;
+    });
+
+    await runWithConcurrency(tasks, 0);
+    expect(maxActive).toBe(1);
+  });
+
+  it('propagates error from a failing task', async () => {
+    const tasks = [
+      async () => {},
+      async () => { throw new Error('boom'); },
+      async () => {},
+    ];
+
+    await expect(runWithConcurrency(tasks, 2)).rejects.toThrow('boom');
+  });
+
+  it('executes all tasks exactly once', async () => {
+    const calls: number[] = [];
+    const tasks = [1, 2, 3, 4, 5].map((n) => async () => {
+      calls.push(n);
+    });
+
+    await runWithConcurrency(tasks, 3);
+    expect(calls.sort()).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/tests/unit/utils/concurrency.test.ts
+++ b/tests/unit/utils/concurrency.test.ts
@@ -68,6 +68,18 @@ describe('runWithConcurrency', () => {
     await expect(runWithConcurrency(tasks, 2)).rejects.toThrow('boom');
   });
 
+  it('stops scheduling new tasks after first error', async () => {
+    const executed: number[] = [];
+    const tasks = Array.from({ length: 20 }, (_, i) => async () => {
+      executed.push(i);
+      if (i === 2) throw new Error('fail');
+      await new Promise((r) => setTimeout(r, 5));
+    });
+
+    await expect(runWithConcurrency(tasks, 1)).rejects.toThrow('fail');
+    expect(executed.length).toBeLessThan(20);
+  });
+
   it('executes all tasks exactly once', async () => {
     const calls: number[] = [];
     const tasks = [1, 2, 3, 4, 5].map((n) => async () => {

--- a/tests/unit/utils/hash.test.ts
+++ b/tests/unit/utils/hash.test.ts
@@ -1,0 +1,29 @@
+import crypto from 'node:crypto';
+import { sha256Base64, verifyHash } from '../../../src/utils/hash.js';
+
+describe('sha256Base64', () => {
+  it('computes correct SHA-256 base64 for known input', () => {
+    const data = new TextEncoder().encode('hello world');
+    const expected = crypto.createHash('sha256').update(data).digest('base64');
+    expect(sha256Base64(data)).toBe(expected);
+  });
+
+  it('computes correct hash for empty input', () => {
+    const data = new Uint8Array(0);
+    const expected = crypto.createHash('sha256').update(data).digest('base64');
+    expect(sha256Base64(data)).toBe(expected);
+  });
+});
+
+describe('verifyHash', () => {
+  it('returns true when hash matches', () => {
+    const data = new TextEncoder().encode('test data');
+    const hash = crypto.createHash('sha256').update(data).digest('base64');
+    expect(verifyHash(data, hash)).toBe(true);
+  });
+
+  it('returns false when hash does not match', () => {
+    const data = new TextEncoder().encode('test data');
+    expect(verifyHash(data, 'wrong-hash')).toBe(false);
+  });
+});

--- a/tests/unit/validation/patterns.test.ts
+++ b/tests/unit/validation/patterns.test.ts
@@ -113,6 +113,11 @@ describe('isValidNipVatUe', () => {
     expect(isValidNipVatUe('0123456789-ATU12345678')).toBe(false);
   });
 
+  it('rejects NIP with invalid checksum', () => {
+    // 1234567890 passes NIP regex pattern but fails mod-11 checksum
+    expect(isValidNipVatUe('1234567890-DE123456789')).toBe(false);
+  });
+
   it('rejects empty string', () => {
     expect(isValidNipVatUe('')).toBe(false);
   });

--- a/tests/unit/workflows/batch-session-workflow.test.ts
+++ b/tests/unit/workflows/batch-session-workflow.test.ts
@@ -177,6 +177,24 @@ describe('uploadBatch', () => {
     expect(client.sessionStatus.getSessionUpo).toHaveBeenCalledWith('batch-ref-1', 'upo-batch-1');
   });
 
+  it('passes parallelism to sendParts', async () => {
+    await uploadBatch(client, zipData, { parallelism: 3, pollOptions: { intervalMs: 1 } });
+    expect(client.batchSession.sendParts).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      3,
+    );
+  });
+
+  it('passes undefined parallelism when not specified', async () => {
+    await uploadBatch(client, zipData, { pollOptions: { intervalMs: 1 } });
+    expect(client.batchSession.sendParts).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
+    );
+  });
+
   it('returns empty pages when upo is undefined', async () => {
     client.sessionStatus.getSessionStatus.mockResolvedValue({
       status: { code: 200, description: 'OK' },
@@ -242,6 +260,24 @@ describe('uploadBatchStream', () => {
     await uploadBatchStream(client, zipStreamFactory, zipData.length, { pollOptions: { intervalMs: 1 } });
     expect(client.batchSession.sendPartsWithStream).toHaveBeenCalled();
     expect(client.batchSession.sendParts).not.toHaveBeenCalled();
+  });
+
+  it('passes parallelism to sendPartsWithStream', async () => {
+    await uploadBatchStream(client, zipStreamFactory, zipData.length, { parallelism: 2, pollOptions: { intervalMs: 1 } });
+    expect(client.batchSession.sendPartsWithStream).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      2,
+    );
+  });
+
+  it('passes undefined parallelism when not specified', async () => {
+    await uploadBatchStream(client, zipStreamFactory, zipData.length, { pollOptions: { intervalMs: 1 } });
+    expect(client.batchSession.sendPartsWithStream).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
+    );
   });
 
   it('uploadBatchStreamParsed fetches and parses UPO pages', async () => {

--- a/tests/unit/workflows/batch-session-workflow.test.ts
+++ b/tests/unit/workflows/batch-session-workflow.test.ts
@@ -177,6 +177,11 @@ describe('uploadBatch', () => {
     expect(client.sessionStatus.getSessionUpo).toHaveBeenCalledWith('batch-ref-1', 'upo-batch-1');
   });
 
+  it.each([0, -1, 1.5, NaN])('rejects invalid parallelism: %s', async (parallelism) => {
+    await expect(uploadBatch(client, zipData, { parallelism, pollOptions: { intervalMs: 1 } }))
+      .rejects.toThrow('parallelism must be a positive integer');
+  });
+
   it('passes parallelism to sendParts', async () => {
     await uploadBatch(client, zipData, { parallelism: 3, pollOptions: { intervalMs: 1 } });
     expect(client.batchSession.sendParts).toHaveBeenCalledWith(
@@ -260,6 +265,11 @@ describe('uploadBatchStream', () => {
     await uploadBatchStream(client, zipStreamFactory, zipData.length, { pollOptions: { intervalMs: 1 } });
     expect(client.batchSession.sendPartsWithStream).toHaveBeenCalled();
     expect(client.batchSession.sendParts).not.toHaveBeenCalled();
+  });
+
+  it.each([0, -1, 1.5, NaN])('rejects invalid parallelism: %s', async (parallelism) => {
+    await expect(uploadBatchStream(client, zipStreamFactory, zipData.length, { parallelism, pollOptions: { intervalMs: 1 } }))
+      .rejects.toThrow('parallelism must be a positive integer');
   });
 
   it('passes parallelism to sendPartsWithStream', async () => {

--- a/tests/unit/workflows/incremental-export-workflow.test.ts
+++ b/tests/unit/workflows/incremental-export-workflow.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ContinuationPoints } from '../../../src/workflows/hwm-coordinator.js';
 import type { ExportResult } from '../../../src/workflows/types.js';
 import type { HwmStore } from '../../../src/workflows/hwm-storage.js';
+import { sha256Base64 } from '../../../src/utils/hash.js';
+
+/** Pre-computed SHA-256 base64 of the mock encrypted data [99, 99]. */
+const MOCK_ENC_HASH = sha256Base64(new Uint8Array([99, 99]));
 
 // Mock doExport before importing the module under test
 vi.mock('../../../src/workflows/invoice-export-workflow.js', () => ({
@@ -46,8 +50,9 @@ function mockExportResult(overrides: Partial<ExportResult> & { referenceNumber?:
           url: 'https://dl.example.com/1',
           method: 'GET',
           partSize: 100,
+          partHash: 'ph1',
           encryptedPartSize: 110,
-          encryptedPartHash: 'h1',
+          encryptedPartHash: MOCK_ENC_HASH,
           expirationDate: '2026-12-31',
         },
       ],
@@ -474,8 +479,9 @@ describe('incrementalExportAndDownload', () => {
                 url: 'https://dl.example.com/a1',
                 method: 'GET',
                 partSize: 100,
+                partHash: 'ph',
                 encryptedPartSize: 110,
-                encryptedPartHash: 'ha1',
+                encryptedPartHash: MOCK_ENC_HASH,
                 expirationDate: '2026-12-31',
               },
             ],
@@ -491,8 +497,9 @@ describe('incrementalExportAndDownload', () => {
                 url: 'https://dl.example.com/b1',
                 method: 'GET',
                 partSize: 200,
+                partHash: 'ph',
                 encryptedPartSize: 210,
-                encryptedPartHash: 'hb1',
+                encryptedPartHash: MOCK_ENC_HASH,
                 expirationDate: '2026-12-31',
               },
             ],
@@ -526,8 +533,9 @@ describe('incrementalExportAndDownload', () => {
               url: 'https://dl.example.com/p1',
               method: 'GET',
               partSize: 100,
+              partHash: 'ph',
               encryptedPartSize: 110,
-              encryptedPartHash: 'h1',
+              encryptedPartHash: MOCK_ENC_HASH,
               expirationDate: '2026-12-31',
             },
             {
@@ -535,8 +543,9 @@ describe('incrementalExportAndDownload', () => {
               url: 'https://dl.example.com/p2',
               method: 'GET',
               partSize: 200,
+              partHash: 'ph',
               encryptedPartSize: 210,
-              encryptedPartHash: 'h2',
+              encryptedPartHash: MOCK_ENC_HASH,
               expirationDate: '2026-12-31',
             },
             {
@@ -544,8 +553,9 @@ describe('incrementalExportAndDownload', () => {
               url: 'https://dl.example.com/p3',
               method: 'GET',
               partSize: 300,
+              partHash: 'ph',
               encryptedPartSize: 310,
-              encryptedPartHash: 'h3',
+              encryptedPartHash: MOCK_ENC_HASH,
               expirationDate: '2026-12-31',
             },
           ],

--- a/tests/unit/workflows/invoice-export-workflow.test.ts
+++ b/tests/unit/workflows/invoice-export-workflow.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { exportInvoices, exportAndDownload } from '../../../src/workflows/invoice-export-workflow.js';
 import type { InvoiceQueryFilters } from '../../../src/models/invoices/types.js';
+import { sha256Base64 } from '../../../src/utils/hash.js';
 
 function createMockClient() {
   return {
@@ -147,6 +148,7 @@ describe('exportAndDownload', () => {
     const result = await exportAndDownload(client, filters, {
       pollOptions: { intervalMs: 1 },
       transport: mockTransport,
+      verifyHash: false,
     });
 
     expect(mockTransport).toHaveBeenCalledTimes(2);
@@ -180,6 +182,7 @@ describe('exportAndDownload', () => {
     await exportAndDownload(client, filters, {
       pollOptions: { intervalMs: 1 },
       transport: mockTransport,
+      verifyHash: false,
     });
 
     const encData = client.crypto.getEncryptionData();
@@ -188,5 +191,54 @@ describe('exportAndDownload', () => {
       encData.cipherKey,
       encData.cipherIv,
     );
+  });
+
+  it('throws on hash mismatch when verifyHash is enabled', async () => {
+    const mockTransport = vi.fn().mockImplementation(async () =>
+      new Response(new Uint8Array([1, 2, 3]).buffer, { status: 200 }),
+    );
+
+    await expect(
+      exportAndDownload(client, filters, {
+        pollOptions: { intervalMs: 1 },
+        transport: mockTransport,
+      }),
+    ).rejects.toThrow('Hash mismatch for export part 1');
+  });
+
+  it('passes when encrypted data hash matches encryptedPartHash', async () => {
+    const encryptedBytes = new Uint8Array([99, 99, 99]);
+    const correctHash = sha256Base64(encryptedBytes);
+
+    client.invoices.getInvoiceExportStatus.mockResolvedValue({
+      status: { code: 200, description: 'OK' },
+      package: {
+        invoiceCount: 1,
+        size: 100,
+        isTruncated: false,
+        parts: [{
+          ordinalNumber: 1,
+          partName: 'part-1.zip',
+          method: 'GET',
+          url: 'https://download.example.com/1',
+          partSize: 3,
+          partHash: 'ph',
+          encryptedPartSize: 3,
+          encryptedPartHash: correctHash,
+          expirationDate: '2025-12-31',
+        }],
+      },
+    });
+
+    const mockTransport = vi.fn().mockImplementation(async () =>
+      new Response(encryptedBytes.slice().buffer, { status: 200 }),
+    );
+
+    const result = await exportAndDownload(client, filters, {
+      pollOptions: { intervalMs: 1 },
+      transport: mockTransport,
+    });
+
+    expect(result.decryptedParts).toHaveLength(1);
   });
 });

--- a/tests/unit/workflows/online-session-workflow.test.ts
+++ b/tests/unit/workflows/online-session-workflow.test.ts
@@ -255,6 +255,18 @@ describe('getState', () => {
     expect(() => handle.getState()).toThrow('Cannot serialize session state: no access token available');
   });
 
+  it('includes validate flag when true', async () => {
+    const handle = await openOnlineSession(client, { validate: true });
+    const state = handle.getState();
+    expect(state.validate).toBe(true);
+  });
+
+  it('omits validate flag when not set', async () => {
+    const handle = await openOnlineSession(client);
+    const state = handle.getState();
+    expect(state.validate).toBeUndefined();
+  });
+
   it('state is JSON-serializable round-trip', async () => {
     const handle = await openOnlineSession(client);
     const state = handle.getState();
@@ -327,6 +339,20 @@ describe('resumeOnlineSession', () => {
     expect(state.accessToken).toBe('saved-token-123');
     expect(state.aesKey).toBe(savedState.aesKey);
     expect(state.iv).toBe(savedState.iv);
+  });
+
+  it('restores validate flag from state', () => {
+    const stateWithValidate = { ...savedState, validate: true };
+    const handle = resumeOnlineSession(client, stateWithValidate);
+    const restored = handle.getState();
+    expect(restored.validate).toBe(true);
+  });
+
+  it('options.validate overrides state.validate', () => {
+    const stateWithValidate = { ...savedState, validate: true };
+    const handle = resumeOnlineSession(client, stateWithValidate, { validate: false });
+    const restored = handle.getState();
+    expect(restored.validate).toBeUndefined();
   });
 
   it('full round-trip: open → getState → JSON → resumeOnlineSession → sendInvoice', async () => {

--- a/tests/unit/workflows/online-session-workflow.test.ts
+++ b/tests/unit/workflows/online-session-workflow.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { openOnlineSession, resumeOnlineSession, openSendAndClose } from '../../../src/workflows/online-session-workflow.js';
 import { KSeFValidationError } from '../../../src/errors/ksef-validation-error.js';
+import { KSeFSessionExpiredError } from '../../../src/errors/ksef-session-expired-error.js';
 import { validate as validateInvoice } from '../../../src/validation/invoice-validator.js';
 import type { UpoPotwierdzenie } from '../../../src/xml/index.js';
 
@@ -236,6 +237,12 @@ describe('getState', () => {
     expect(Buffer.from(state.iv, 'base64')).toHaveLength(16);
   });
 
+  it('throws when access token is unavailable', async () => {
+    const handle = await openOnlineSession(client);
+    client.authManager.getAccessToken.mockReturnValue(undefined);
+    expect(() => handle.getState()).toThrow('Cannot serialize session state: no access token available');
+  });
+
   it('state is JSON-serializable round-trip', async () => {
     const handle = await openOnlineSession(client);
     const state = handle.getState();
@@ -254,6 +261,15 @@ describe('resumeOnlineSession', () => {
     formCode: { systemCode: 'FA (3)' as const, schemaVersion: '1-0E' as const, value: 'FA' as const },
     validUntil: '2099-06-01T00:00:00Z',
   };
+
+  it('throws KSeFSessionExpiredError for expired session', () => {
+    const expiredState = {
+      ...savedState,
+      validUntil: '2020-01-01T00:00:00Z',
+    };
+    expect(() => resumeOnlineSession(client, expiredState)).toThrow(KSeFSessionExpiredError);
+    expect(() => resumeOnlineSession(client, expiredState)).toThrow('Cannot resume session: expired at 2020-01-01T00:00:00Z');
+  });
 
   it('restores handle with correct sessionRef and validUntil', () => {
     const handle = resumeOnlineSession(client, savedState);

--- a/tests/unit/workflows/online-session-workflow.test.ts
+++ b/tests/unit/workflows/online-session-workflow.test.ts
@@ -11,6 +11,17 @@ vi.mock('../../../src/validation/invoice-validator.js', () => ({
 
 const mockValidateInvoice = vi.mocked(validateInvoice);
 
+function createMockScopedRestClient() {
+  return {
+    execute: vi.fn().mockResolvedValue({
+      body: { referenceNumber: 'inv-ref-1' },
+      headers: new Headers(),
+      statusCode: 200,
+    }),
+    executeVoid: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 function createMockClient() {
   let _token = 'test-access-token';
   return {
@@ -18,6 +29,7 @@ function createMockClient() {
       getAccessToken: vi.fn(() => _token),
       setAccessToken: vi.fn((t: string) => { _token = t; }),
     },
+    createScopedRestClient: vi.fn().mockReturnValue(createMockScopedRestClient()),
     crypto: {
       init: vi.fn(),
       getEncryptionData: vi.fn().mockReturnValue({
@@ -277,31 +289,42 @@ describe('resumeOnlineSession', () => {
     expect(handle.validUntil).toBe('2099-06-01T00:00:00Z');
   });
 
-  it('sets access token on client authManager', () => {
+  it('does not modify client authManager', () => {
     resumeOnlineSession(client, savedState);
-    expect(client.authManager.setAccessToken).toHaveBeenCalledWith('saved-token-123');
+    expect(client.authManager.setAccessToken).not.toHaveBeenCalled();
+    expect(client.authManager.getAccessToken()).toBe('test-access-token');
   });
 
-  it('resumed handle can send invoices', async () => {
+  it('creates scoped RestClient via client.createScopedRestClient', () => {
+    resumeOnlineSession(client, savedState);
+    expect(client.createScopedRestClient).toHaveBeenCalledWith(
+      expect.objectContaining({ getAccessToken: expect.any(Function) }),
+    );
+    const scopedAuth = client.createScopedRestClient.mock.calls[0][0];
+    expect(scopedAuth.getAccessToken()).toBe('saved-token-123');
+  });
+
+  it('resumed handle can send invoices via scoped services', async () => {
     const handle = resumeOnlineSession(client, savedState);
     const ref = await handle.sendInvoice('<invoice>resumed</invoice>');
     expect(ref).toBe('inv-ref-1');
-    expect(client.onlineSession.sendInvoice).toHaveBeenCalledWith(
-      'sess-ref-saved',
-      expect.objectContaining({ encryptedInvoiceContent: expect.any(String) }),
-    );
+    expect(client.crypto.encryptAES256).toHaveBeenCalled();
+    // Uses scoped services, not client.onlineSession
+    expect(client.onlineSession.sendInvoice).not.toHaveBeenCalled();
   });
 
-  it('resumed handle can close session', async () => {
+  it('resumed handle can close session via scoped services', async () => {
     const handle = resumeOnlineSession(client, savedState);
     await handle.close();
-    expect(client.onlineSession.closeSession).toHaveBeenCalledWith('sess-ref-saved');
+    // Uses scoped services, not client.onlineSession
+    expect(client.onlineSession.closeSession).not.toHaveBeenCalled();
   });
 
-  it('resumed handle.getState() returns current state', () => {
+  it('resumed handle.getState() returns scoped token, not client token', () => {
     const handle = resumeOnlineSession(client, savedState);
     const state = handle.getState();
     expect(state.referenceNumber).toBe('sess-ref-saved');
+    expect(state.accessToken).toBe('saved-token-123');
     expect(state.aesKey).toBe(savedState.aesKey);
     expect(state.iv).toBe(savedState.iv);
   });
@@ -317,11 +340,8 @@ describe('resumeOnlineSession', () => {
 
     const ref = await handle2.sendInvoice('<invoice>round-trip</invoice>');
     expect(ref).toBe('inv-ref-1');
-    expect(client2.authManager.setAccessToken).toHaveBeenCalled();
-    expect(client2.onlineSession.sendInvoice).toHaveBeenCalledWith(
-      'sess-ref-1',
-      expect.any(Object),
-    );
+    // Auth is scoped — client2.authManager is untouched
+    expect(client2.authManager.setAccessToken).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/workflows/online-session-workflow.test.ts
+++ b/tests/unit/workflows/online-session-workflow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { openOnlineSession, openSendAndClose } from '../../../src/workflows/online-session-workflow.js';
+import { openOnlineSession, resumeOnlineSession, openSendAndClose } from '../../../src/workflows/online-session-workflow.js';
 import { KSeFValidationError } from '../../../src/errors/ksef-validation-error.js';
 import { validate as validateInvoice } from '../../../src/validation/invoice-validator.js';
 import type { UpoPotwierdzenie } from '../../../src/xml/index.js';
@@ -11,7 +11,12 @@ vi.mock('../../../src/validation/invoice-validator.js', () => ({
 const mockValidateInvoice = vi.mocked(validateInvoice);
 
 function createMockClient() {
+  let _token = 'test-access-token';
   return {
+    authManager: {
+      getAccessToken: vi.fn(() => _token),
+      setAccessToken: vi.fn((t: string) => { _token = t; }),
+    },
     crypto: {
       init: vi.fn(),
       getEncryptionData: vi.fn().mockReturnValue({
@@ -212,6 +217,95 @@ describe('openSendAndClose', () => {
     expect(client.onlineSession.sendInvoice).toHaveBeenCalledTimes(2);
     expect(client.onlineSession.closeSession).toHaveBeenCalledWith('sess-ref-1');
     expect(upo.pages).toHaveLength(1);
+  });
+});
+
+describe('getState', () => {
+  it('returns serializable session state', async () => {
+    const handle = await openOnlineSession(client);
+    const state = handle.getState();
+
+    expect(state.referenceNumber).toBe('sess-ref-1');
+    expect(state.validUntil).toBe('2099-01-01T00:00:00Z');
+    expect(state.accessToken).toBe('test-access-token');
+    expect(state.formCode).toEqual({ systemCode: 'FA (3)', schemaVersion: '1-0E', value: 'FA' });
+    expect(typeof state.aesKey).toBe('string');
+    expect(typeof state.iv).toBe('string');
+    // Base64-encoded keys should be decodable
+    expect(Buffer.from(state.aesKey, 'base64')).toHaveLength(32);
+    expect(Buffer.from(state.iv, 'base64')).toHaveLength(16);
+  });
+
+  it('state is JSON-serializable round-trip', async () => {
+    const handle = await openOnlineSession(client);
+    const state = handle.getState();
+    const json = JSON.stringify(state);
+    const restored = JSON.parse(json);
+    expect(restored).toEqual(state);
+  });
+});
+
+describe('resumeOnlineSession', () => {
+  const savedState = {
+    referenceNumber: 'sess-ref-saved',
+    aesKey: Buffer.from(new Uint8Array(32)).toString('base64'),
+    iv: Buffer.from(new Uint8Array(16)).toString('base64'),
+    accessToken: 'saved-token-123',
+    formCode: { systemCode: 'FA (3)' as const, schemaVersion: '1-0E' as const, value: 'FA' as const },
+    validUntil: '2099-06-01T00:00:00Z',
+  };
+
+  it('restores handle with correct sessionRef and validUntil', () => {
+    const handle = resumeOnlineSession(client, savedState);
+    expect(handle.sessionRef).toBe('sess-ref-saved');
+    expect(handle.validUntil).toBe('2099-06-01T00:00:00Z');
+  });
+
+  it('sets access token on client authManager', () => {
+    resumeOnlineSession(client, savedState);
+    expect(client.authManager.setAccessToken).toHaveBeenCalledWith('saved-token-123');
+  });
+
+  it('resumed handle can send invoices', async () => {
+    const handle = resumeOnlineSession(client, savedState);
+    const ref = await handle.sendInvoice('<invoice>resumed</invoice>');
+    expect(ref).toBe('inv-ref-1');
+    expect(client.onlineSession.sendInvoice).toHaveBeenCalledWith(
+      'sess-ref-saved',
+      expect.objectContaining({ encryptedInvoiceContent: expect.any(String) }),
+    );
+  });
+
+  it('resumed handle can close session', async () => {
+    const handle = resumeOnlineSession(client, savedState);
+    await handle.close();
+    expect(client.onlineSession.closeSession).toHaveBeenCalledWith('sess-ref-saved');
+  });
+
+  it('resumed handle.getState() returns current state', () => {
+    const handle = resumeOnlineSession(client, savedState);
+    const state = handle.getState();
+    expect(state.referenceNumber).toBe('sess-ref-saved');
+    expect(state.aesKey).toBe(savedState.aesKey);
+    expect(state.iv).toBe(savedState.iv);
+  });
+
+  it('full round-trip: open → getState → JSON → resumeOnlineSession → sendInvoice', async () => {
+    const handle1 = await openOnlineSession(client);
+    const json = JSON.stringify(handle1.getState());
+
+    // Simulate restart with new client
+    const client2 = createMockClient();
+    const restored = JSON.parse(json);
+    const handle2 = resumeOnlineSession(client2, restored);
+
+    const ref = await handle2.sendInvoice('<invoice>round-trip</invoice>');
+    expect(ref).toBe('inv-ref-1');
+    expect(client2.authManager.setAccessToken).toHaveBeenCalled();
+    expect(client2.onlineSession.sendInvoice).toHaveBeenCalledWith(
+      'sess-ref-1',
+      expect.any(Object),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- **Session state serialization** — online sessions can be serialized to JSON and restored across process restarts for fault-tolerant invoice sending
- **File hash verification** — downloaded invoices and export parts verified against SHA-256 `x-ms-meta-hash` header
- **Polish statutory holidays** — deadline calculation now skips 14 public holidays, not just weekends
- **VAT-EU validation** — format validation for all 27 EU member states + NIP checksum
- **Parallel batch upload** — configurable `parallelism` option for bounded concurrent part uploads (CLI `--parallelism` flag)
- **Bugfix** — `sendParts()` now checks presigned URL response status instead of silently ignoring errors

## Test plan
- [x] `yarn lint` — type-check passes
- [x] `yarn test` — 1587 unit tests pass (98 files)
- [x] `yarn test:e2e` — 96 E2E tests pass (32 files) against KSeF TEST

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save and resume online sessions via session state export/import
  * SHA-256 verification for downloaded invoices and export parts (enabled by default, opt‑out available)
  * Configurable batch upload concurrency (CLI --parallelism and batch upload option)
  * Invoice JSON output now includes a download hash when available

* **Bug Fixes**
  * Presigned upload failures are now detected and reported
  * Business‑day deadline calculations now skip Polish statutory holidays

* **Documentation**
  * Added Polish Holidays reference guide
<!-- end of auto-generated comment: release notes by coderabbit.ai -->