### PR TITLE
ci(claude-review): grant id-token: write

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write  # required by anthropics/claude-code-action@v1 (fetches OIDC token)
 
 concurrency:
   group: claude-review-${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary

- Adds `id-token: write` to workflow permissions so `anthropics/claude-code-action@v1` can fetch an OIDC token
- Without it the action fails with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable` (three retries, then exit 1)
- Minimum extra permission; other scopes unchanged (`contents: read`, `pull-requests: write`)

Follow-up to #12. See failing run: https://github.com/Flopsstuff/ksef-client-ts/actions/runs/24612165954

## Test plan

- [ ] After merge, post `@claude-review` on a PR and confirm the action completes and leaves a review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)