### PR TITLE
ci(claude-review): use claude_code_oauth_token for OAuth auth

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run Claude review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude-review"
           claude_args: "--max-turns 8 --model claude-sonnet-4-6"
           prompt: ${{ steps.render.outputs.prompt }}


### PR DESCRIPTION
## Summary

The action has two distinct auth inputs:
- `anthropic_api_key:` — expects `sk-ant-api-*` (REST API key)
- `claude_code_oauth_token:` — expects `sk-ant-oat-*` (OAuth token from `claude setup-token`)

We store the OAuth token in `CLAUDE_CODE_OAUTH_TOKEN`; passing it to the `anthropic_api_key` input was rejected upstream with `Invalid API key · Fix external API key`.

Follow-up to #13. See failing run: https://github.com/Flopsstuff/ksef-client-ts/actions/runs/24612294483

## Test plan

- [ ] After merge, post `@claude-review` on a PR and confirm the action authenticates and leaves a review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)