### PR TITLE
ci(claude-review): raise max-turns from 8 to 25

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -66,5 +66,5 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude-review"
-          claude_args: "--max-turns 8 --model claude-sonnet-4-6"
+          claude_args: "--max-turns 25 --model claude-sonnet-4-6"
           prompt: ${{ steps.render.outputs.prompt }}


### PR DESCRIPTION
## Summary

- Bumps --max-turns from 8 to 25 in the @claude-review workflow
- Follow-up to #14; previous run hit the 8-turn ceiling before finishing

## Context

Per-PR review work load: read git diff, read CLAUDE.md, spot-read changed files, cross-check CHANGELOG / docs. 8 turns was not enough in practice.

See: https://github.com/Flopsstuff/ksef-client-ts/actions/runs/24612375742/job/71969074803

## Test plan

- [ ] After merge, post @claude-review on an open PR; expect completion within the new ceiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
