### PR TITLE
ci(claude-review): drop prompt input to restore tag mode

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -47,24 +47,12 @@ jobs:
           ref: refs/pull/${{ steps.pr.outputs.number }}/merge
           fetch-depth: 0
 
-      - name: Render review prompt
-        id: render
-        env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          BASE_REF: ${{ steps.pr.outputs.base_ref }}
-        # envsubst with an explicit allowlist — only $PR_NUMBER and $BASE_REF
-        # get substituted; any other $var in the prompt is left verbatim.
-        run: |
-          {
-            echo 'prompt<<PROMPT_EOF'
-            envsubst '$PR_NUMBER $BASE_REF' < .github/claude/prompts/review.md
-            echo 'PROMPT_EOF'
-          } >> "$GITHUB_OUTPUT"
-
       - name: Run Claude review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude-review"
+          # Omitting `prompt:` keeps the action in tag mode so Claude's
+          # response is posted as a PR comment. The review checklist lives
+          # in .github/claude/prompts/review.md, surfaced via CLAUDE.md.
           claude_args: "--max-turns 25 --model claude-sonnet-4-6"
-          prompt: ${{ steps.render.outputs.prompt }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,3 +165,4 @@ Feature descriptions live in two places that must be kept in sync: `README.md` (
 - Always merge PRs with `--squash`. Merge commits are disabled on this repository.
 - When squash-merging, edit the combined commit message to remove duplicate `Co-Authored-By` lines from individual commits — keep only a single `Co-Authored-By` at the very end.
 - Name version branches with `version/` prefix (e.g. `version/v0.6.1`) to avoid conflicts with release tags.
+- When responding to a `@claude-review` comment on a pull request, read `.github/claude/prompts/review.md` from the repo root and follow its checklist and output format as the review instructions.


### PR DESCRIPTION
## Summary

The `@claude-review` action was running but never commenting on PRs. Root cause: supplying a `prompt:` input auto-detects agent mode, which skips the PR-comment-reply behavior.

Fix:

- Remove `prompt:` (and the rendering step that produced it) → action falls back to tag mode
- Move the review checklist into `CLAUDE.md` as an explicit rule pointing to `.github/claude/prompts/review.md`

Tag mode posts the assistant's response as a PR comment directly. Claude still follows our custom checklist because it reads `CLAUDE.md` on startup and discovers the review prompt file from there.

Follow-up to #15.

## Test plan

- [ ] After merge, post `@claude-review` on an open PR; expect a comment from `claude[bot]` with findings per the review.md checklist
- [ ] Verify `num_turns` < 25 (no `prompt:` means less exploration work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
